### PR TITLE
11 add minshards to initializesarcophagus

### DIFF
--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -36,8 +36,8 @@ contract EmbalmerFacet {
     /// @param arweaveArchaeologist The address of the archaeologist who uploads to arweave
     /// @param recipient the address of the recipient
     /// @param resurrectionTime the resurrection time of the sarcophagus
-    /// @param sarcoToken The erc20 sarcophagus token
     /// @param canBeTransferred Whether the sarcophagus can be transferred
+    /// @param minShards The minimum number of shards
     /// @return The index of the new sarcophagus
     function initializeSarcophagus(
         string memory name,
@@ -46,8 +46,8 @@ contract EmbalmerFacet {
         address arweaveArchaeologist,
         address recipient,
         uint256 resurrectionTime,
-        IERC20 sarcoToken,
-        bool canBeTransferred
+        bool canBeTransferred,
+        uint8 minShards
     ) external returns (uint256) {
         // Confirm that this exact sarcophagus does not already exist
         if (
@@ -65,6 +65,16 @@ contract EmbalmerFacet {
         // Confirm that archaeologists are provided
         if (archaeologists.length == 0) {
             revert LibErrors.NoArchaeologistsProvided();
+        }
+
+        // Confirm that minShards to less than the number of archaeologists
+        if (minShards > archaeologists.length) {
+            revert LibErrors.MinShardsGreaterThanArchaeologists(minShards);
+        }
+
+        // Confirm that minShards is greater than 0
+        if (minShards == 0) {
+            revert LibErrors.MinShardsZero();
         }
 
         // Initialize a list of archaeologist addresses to be passed in to the
@@ -131,6 +141,7 @@ contract EmbalmerFacet {
             name: name,
             state: LibTypes.SarcophagusState.Exists,
             canBeTransferred: canBeTransferred,
+            minShards: minShards,
             resurrectionTime: resurrectionTime,
             arweaveTxId: "",
             storageFee: storageFee,

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -164,7 +164,7 @@ contract EmbalmerFacet {
         );
 
         // Transfer the total fees amount in sarco token from the msg.sender to this contract
-        sarcoToken.transferFrom(msg.sender, address(this), totalFees);
+        s.sarcoToken.transferFrom(msg.sender, address(this), totalFees);
 
         // Emit the event
         emit LibEvents.InitializeSarcophagus(
@@ -202,14 +202,12 @@ contract EmbalmerFacet {
     /// This is archaeologist.length - 1 since the arweave archaeologist will be providing their own signature.
     /// @param arweaveArchaeologistSignature the signature of the archaeologist who uploaded to arweave
     /// @param arweaveTxId the arweave transaction id
-    /// @param sarcoToken The erc20 sarcophagus token
     /// @return The boolean true if the operation was successful
     function finalizeSarcophagus(
         bytes32 identifier,
         LibTypes.SignatureWithAccount[] memory archaeologistSignatures,
         LibTypes.Signature memory arweaveArchaeologistSignature,
-        string memory arweaveTxId,
-        IERC20 sarcoToken
+        string memory arweaveTxId
     ) external returns (bool) {
         // Confirm that the sarcophagus exists
         if (
@@ -302,7 +300,7 @@ contract EmbalmerFacet {
 
         // Transfer the storage fee to the arweave archaeologist after setting
         // the arweave transaction id.
-        sarcoToken.transfer(
+        s.sarcoToken.transfer(
             s.sarcophaguses[identifier].arweaveArchaeologist,
             s.sarcophaguses[identifier].storageFee
         );

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -35,4 +35,8 @@ library LibErrors {
     );
 
     error ArchaeologistNotOnSarcophagus(address archaeologist);
+
+    error MinShardsGreaterThanArchaeologists(uint8 minShards);
+
+    error MinShardsZero();
 }

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -74,6 +74,7 @@ library LibTypes {
         string name;
         SarcophagusState state;
         bool canBeTransferred;
+        uint8 minShards;
         uint256 resurrectionTime;
         string arweaveTxId;
         uint256 storageFee;

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -76,7 +76,7 @@ library LibUtils {
         bytes32 r,
         bytes32 s,
         address account
-    ) public view {
+    ) internal pure {
         // Hash the hash of the data payload
         bytes32 messageHash = keccak256(
             abi.encodePacked(
@@ -115,7 +115,7 @@ library LibUtils {
         bytes32 r,
         bytes32 s,
         address account
-    ) public view {
+    ) internal pure {
         // Hash the hash of the data payload
         bytes32 messageHash = keccak256(
             abi.encodePacked(

--- a/contracts/storage/AppStorageInit.sol
+++ b/contracts/storage/AppStorageInit.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.9;
+
+import "hardhat/console.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./LibAppStorage.sol";
+
+contract AppStorageInit {
+    /// @notice Initializes the app with default state values
+    /// @dev Add any AppStorage struct properties here to initialize values
+    function init(IERC20 sarcoToken) external {
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        // Add the ERC20 token to app storage (Sarco)
+        s.sarcoToken = sarcoToken;
+    }
+}

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.9;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../libraries/LibTypes.sol";
 
 // Global storage for the app. Can be accessed in facets and in libraries
 struct AppStorage {
+    IERC20 sarcoToken;
     // Each archaeologist's total free and cursed bonds
     mapping(address => uint256) freeBonds;
     mapping(address => uint256) cursedBonds;

--- a/test/facets/archaeologist-facet.spec.ts
+++ b/test/facets/archaeologist-facet.spec.ts
@@ -20,7 +20,7 @@ describe("Contract: ArchaeologistFacet", () => {
 
     archaeologist = signers[0];
 
-    diamondAddress = await deployDiamond();
+    diamondAddress = (await deployDiamond()).diamondAddress;
     const SarcoToken = await ethers.getContractFactory("SarcoTokenMock");
     sarcoToken = await SarcoToken.deploy();
     await sarcoToken.deployed();

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -74,7 +74,8 @@ describe("Contract: EmbalmerFacet", () => {
     name: string,
     resurrectionTime: BigNumber,
     identifier: string,
-    archaeologists: any[]
+    archaeologists: any[],
+    minShards?: number
   ): Promise<ContractTransaction> => {
     // Define archaeologist objects to be passed into the sarcophagus
     const archaeologistObjects = archaeologists.map((a, i) => ({
@@ -97,8 +98,8 @@ describe("Contract: EmbalmerFacet", () => {
         arweaveArchaeologist.address,
         recipient.address,
         resurrectionTime,
-        sarcoToken.address,
-        canBeTransfered
+        canBeTransfered,
+        minShards || 3
       );
 
     return tx;
@@ -206,6 +207,30 @@ describe("Contract: EmbalmerFacet", () => {
           []
         )
       ).to.be.revertedWith("NoArchaeologistsProvided");
+    });
+
+    it("should revert if minShards is greater than the number of archaeologists", async () => {
+      expect(
+        initializeSarcophagus(
+          "Test Sarcophagus",
+          BigNumber.from((Date.now() / 1000).toFixed(0)),
+          identifier,
+          archaeologists,
+          5
+        )
+      ).to.be.revertedWith("MinShardsGreaterThanArchaeologists");
+    });
+
+    it("should revert if minShards is 0", async () => {
+      expect(
+        initializeSarcophagus(
+          "Test Sarcophagus",
+          BigNumber.from((Date.now() / 1000).toFixed(0)),
+          identifier,
+          archaeologists,
+          0
+        )
+      ).to.be.revertedWith("MinShardsZero");
     });
 
     it("should revert if an archaeologist does not have enough free bond", async () => {

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -110,11 +110,12 @@ describe("Contract: EmbalmerFacet", () => {
     // This is necessary so that each test will start in a clean state.
     beforeEach(async () => {
       // Deploy the sarco token contract
-      const SarcoToken = await ethers.getContractFactory("SarcoTokenMock");
-      sarcoToken = await SarcoToken.deploy();
-      await sarcoToken.deployed();
 
-      const diamondAddress = await deployDiamond();
+      const { diamondAddress, sarcoToken: _sarcoToken } = await deployDiamond();
+
+      // Set sarcoToken globally
+      sarcoToken = _sarcoToken;
+
       embalmerFacet = await ethers.getContractAt(
         "EmbalmerFacet",
         diamondAddress
@@ -129,18 +130,18 @@ describe("Contract: EmbalmerFacet", () => {
       for (const archaeologist of archaeologists) {
         // Transfer 10,000 sarco tokens to each archaeologist to be put into free
         // bond
-        await sarcoToken.transfer(
+        await _sarcoToken.transfer(
           archaeologist.address,
           BigNumber.from(10_000)
         );
 
         // Approve the archaeologist on the sarco token so transferFrom will work
-        await sarcoToken
+        await _sarcoToken
           .connect(archaeologist)
           .approve(diamondAddress, ethers.constants.MaxUint256);
 
         // Approve the embalmer on the sarco token so transferFrom will work
-        await sarcoToken
+        await _sarcoToken
           .connect(embalmer)
           .approve(diamondAddress, ethers.constants.MaxUint256);
 
@@ -151,7 +152,7 @@ describe("Contract: EmbalmerFacet", () => {
           .depositFreeBond(
             archaeologist.address,
             BigNumber.from("1000"),
-            sarcoToken.address
+            _sarcoToken.address
           );
       }
     });
@@ -390,12 +391,11 @@ describe("Contract: EmbalmerFacet", () => {
 
     // Deploy the contracts
     before(async () => {
-      // Deploy the sarco token contract
-      const SarcoToken = await ethers.getContractFactory("SarcoTokenMock");
-      sarcoToken = await SarcoToken.deploy();
-      await sarcoToken.deployed();
+      const { diamondAddress: _diamondAddress, sarcoToken: _sarcoToken } =
+        await deployDiamond();
+      diamondAddress = _diamondAddress;
+      sarcoToken = _sarcoToken;
 
-      diamondAddress = await deployDiamond();
       embalmerFacet = await ethers.getContractAt(
         "EmbalmerFacet",
         diamondAddress
@@ -479,8 +479,7 @@ describe("Contract: EmbalmerFacet", () => {
           identifier,
           signatures,
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
       });
 
@@ -539,8 +538,7 @@ describe("Contract: EmbalmerFacet", () => {
           fakeIdentifier,
           signatures,
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         await expect(tx).to.be.revertedWith("SarcophagusDoesNotExist");
@@ -553,8 +551,7 @@ describe("Contract: EmbalmerFacet", () => {
             identifier,
             signatures,
             arweaveSignature,
-            arweaveTxId,
-            sarcoToken.address
+            arweaveTxId
           );
 
         await expect(tx).to.be.revertedWith("SenderNotEmbalmer");
@@ -587,8 +584,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures,
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         // Finalize the sarcophagus with the new identifier again and expect revert
@@ -596,8 +592,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           signatures,
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         await expect(tx).to.be.revertedWith("SarcophagusAlreadyFinalized");
@@ -630,8 +625,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures,
           arweaveSignature,
-          "",
-          sarcoToken.address
+          ""
         );
 
         await expect(tx).to.be.revertedWith("ArweaveTxIdEmpty");
@@ -666,8 +660,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures.slice(1),
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         await expect(tx).to.be.revertedWith(
@@ -710,8 +703,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures,
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         await expect(tx).to.be.revertedWith("ArchaeologistNotOnSarcophagus");
@@ -765,8 +757,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures,
           arweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         await expect(tx).to.be.revertedWith("SignatureFromWrongAccount");
@@ -807,8 +798,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures,
           falseArweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         await expect(tx).to.be.revertedWith("SignatureFromWrongAccount");
@@ -848,8 +838,7 @@ describe("Contract: EmbalmerFacet", () => {
           newIdentifier,
           newSignatures,
           falseArweaveSignature,
-          arweaveTxId,
-          sarcoToken.address
+          arweaveTxId
         );
 
         // Note that it's not possible to get a custom error for this case


### PR DESCRIPTION
# Minshards and sarcoToken modification

This PR is rebased on #9.

### minShards
Adds `minShards` to `initalizeSarcophagus` which is the minimum number of shards required to derive the embalmer's private key. This is the `m` in `m of n`. 

### sarcoToken
Previously the sarcoToken was passed into `initializeSarcophagus` and `finalizeSarcophagus`. Now the sarcoToken is being initialized immediately after the diamond cut for the sarophagus facets. 
In `deploy-diamond.ts`, `calldata` is passed into the diamond cut function. This calls what function is included in calldata with its arguments after a diamond cut happens. 
The first diamond cut in the deploy scripts performs the diamond cut for the facets required for the diamond pattern to work. In this case the calldata is the `init()` function in `DiamondInit.sol`. 
The second diamond cut in the deploy scripts performs the diamond cut for the sarcophagus specific facets (`EmbalmerFacet.so`l and `ArchaeologistFacet.sol`). In this case the calldata is the `init()` function in `AppStorageInit.sol`. The `AppStorageInit.sol` is responsible for initializing any values in AppStorage, like `sarcoToken`. The sarco token may now be accessed from anywhere AppStorage is available. 

According to the diamond pattern, this is exactly what calldata is intended for. There are other ways to initialize the sarco token, but this way keeps the sarcophagus specific code out of the diamond pattern code.
