### PR TITLE
16 unwrap sarcophagus

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../libraries/LibTypes.sol";
+import {LibUtils} from "../libraries/LibUtils.sol";
 import {LibEvents} from "../libraries/LibEvents.sol";
 import {LibErrors} from "../libraries/LibErrors.sol";
 import {LibBonds} from "../libraries/LibBonds.sol";
@@ -83,5 +85,76 @@ contract ArchaeologistFacet {
         returns (uint256)
     {
         return s.cursedBonds[archaeologist];
+    }
+
+    /// @notice Unwraps the sarcophagus.
+    /// @dev Verifies that the unencrypted shard matches the hashedShard stored
+    /// on chain and pays the archaeologist.
+    /// @param identifier The identifier of the sarcophagus
+    /// @param unencryptedShard The archaeologist's corresponding unencrypted shard
+    /// @return The boolean true if the operation was successful
+    function unwrapSarcophagus(
+        bytes32 identifier,
+        bytes memory unencryptedShard
+    ) external returns (bool) {
+        // Confirm that the sarcophagus exists
+        if (
+            s.sarcophaguses[identifier].state !=
+            LibTypes.SarcophagusState.Exists
+        ) {
+            revert LibErrors.SarcophagusDoesNotExist(identifier);
+        }
+
+        // Confirm that the sender is an archaeologist on this sarcophagus
+        if (!LibUtils.archaeologistExistsOnSarc(identifier, msg.sender)) {
+            revert LibErrors.ArchaeologistNotOnSarcophagus(msg.sender);
+        }
+
+        // Confirm that the resurrection time has passed and that the
+        // resurrection window has not passed
+        LibUtils.unwrapTime(
+            s.sarcophaguses[identifier].resurrectionTime,
+            s.sarcophaguses[identifier].resurrectionWindow
+        );
+
+        // Confirm that the archaeologist has not already unwrapped by checking if the unencryptedShard is empty
+        LibUtils.archaeologistUnwrappedCheck(identifier, msg.sender);
+
+        // Get the archaeologist's data from storage
+        LibTypes.ArchaeologistStorage memory archaeologistData = LibUtils
+            .getArchaeologist(identifier, msg.sender);
+
+        // Confirm that the hash of the unencrypted shard matches the hashedShard in storage
+        if (keccak256(unencryptedShard) != archaeologistData.hashedShard) {
+            revert LibErrors.UnencryptedShardHashMismatch(
+                unencryptedShard,
+                archaeologistData.hashedShard
+            );
+        }
+
+        // Store the unencrypted shard in on the archaeologist object in the sarcophagus
+        s
+        .sarcophagusArchaeologists[identifier][msg.sender]
+            .unencryptedShard = unencryptedShard;
+
+        // Set the sarcophagus state as done
+        s.sarcophaguses[identifier].state = LibTypes.SarcophagusState.Done;
+
+        // Free the archaeologist's cursed bond
+        LibBonds.freeArchaeologist(identifier, msg.sender);
+
+        // Save the successful sarcophagus against the archaeologist
+        s.archaeologistSuccesses[msg.sender].push(identifier);
+
+        // Transfer the bounty and digging fee to the archaeologist
+        s.sarcoToken.transfer(
+            msg.sender,
+            archaeologistData.bounty + archaeologistData.diggingFee
+        );
+
+        // Emit an event
+        emit LibEvents.UnwrapSarcophagus(identifier, unencryptedShard);
+
+        return true;
     }
 }

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -120,6 +120,11 @@ contract ArchaeologistFacet {
         // Confirm that the archaeologist has not already unwrapped by checking if the unencryptedShard is empty
         LibUtils.archaeologistUnwrappedCheck(identifier, msg.sender);
 
+        // Comfirm that the sarcophagus has been finalized
+        if (bytes(s.sarcophaguses[identifier].arweaveTxId).length == 0) {
+            revert LibErrors.SarcophagusNotFinalized(identifier);
+        }
+
         // Get the archaeologist's data from storage
         LibTypes.ArchaeologistStorage memory archaeologistData = LibUtils
             .getArchaeologist(identifier, msg.sender);

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -142,9 +142,6 @@ contract ArchaeologistFacet {
         .sarcophagusArchaeologists[identifier][msg.sender]
             .unencryptedShard = unencryptedShard;
 
-        // Set the sarcophagus state as done
-        s.sarcophaguses[identifier].state = LibTypes.SarcophagusState.Done;
-
         // Free the archaeologist's cursed bond
         LibBonds.freeArchaeologist(identifier, msg.sender);
 

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -393,7 +393,7 @@ contract EmbalmerFacet {
 
         // Confirm that the current resurrection time is in the future
         if (s.sarcophaguses[identifier].resurrectionTime <= block.timestamp) {
-            revert LibErrors.ResurrectionTimeInPast(
+            revert LibErrors.NewResurrectionTimeInPast(
                 s.sarcophaguses[identifier].resurrectionTime
             );
         }

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -104,7 +104,10 @@ contract EmbalmerFacet {
             // checking that the archaeologist does not already exist from
             // previous iterations in this loop.
             if (
-                archaeologistExists(identifier, archaeologists[i].archAddress)
+                LibUtils.archaeologistExists(
+                    identifier,
+                    archaeologists[i].archAddress
+                )
             ) {
                 revert LibErrors.ArchaeologistListNotUnique(
                     archaeologistAddresses
@@ -282,7 +285,7 @@ contract EmbalmerFacet {
             // archaeologist on the sarcophagus and run ecrecover to see if
             // there is a match. This is much more efficient.
             if (
-                !archaeologistExists(
+                !LibUtils.archaeologistExists(
                     identifier,
                     archaeologistSignatures[i].account
                 )
@@ -451,7 +454,6 @@ contract EmbalmerFacet {
     /// fees that were locked up will be refunded.
     /// @param identifier the identifier of the sarcophagus
     /// @return The boolean true if the operation was successful
-
     function cancelSarcophagus(bytes32 identifier) external returns (bool) {
         // Confirm that the sender is the embalmer
         if (s.sarcophaguses[identifier].embalmer != msg.sender) {
@@ -578,23 +580,6 @@ contract EmbalmerFacet {
         emit LibEvents.BurySarcophagus(identifier);
 
         return true;
-    }
-
-    /// @notice Checks if the archaeologist exists on the sarcophagus.
-    /// @param identifier the identifier of the sarcophagus
-    /// @param archaeologist the address of the archaeologist
-    /// @return The boolean true if the archaeologist exists on the sarcophagus
-    function archaeologistExists(bytes32 identifier, address archaeologist)
-        private
-        view
-        returns (bool)
-    {
-        // If the hashedShard on an archaeologist is 0 (which is its default
-        // value), then the archaeologist doesn't exist on the sarcophagus
-        return
-            s
-            .sarcophagusArchaeologists[identifier][archaeologist].hashedShard !=
-            0;
     }
 
     /// @notice Gets an archaeologist given the sarcophagus identifier and the

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -104,7 +104,7 @@ contract EmbalmerFacet {
             // checking that the archaeologist does not already exist from
             // previous iterations in this loop.
             if (
-                LibUtils.archaeologistExists(
+                LibUtils.archaeologistExistsOnSarc(
                     identifier,
                     archaeologists[i].archAddress
                 )
@@ -125,7 +125,8 @@ contract EmbalmerFacet {
                 .ArchaeologistStorage({
                     diggingFee: archaeologists[i].diggingFee,
                     bounty: archaeologists[i].bounty,
-                    hashedShard: archaeologists[i].hashedShard
+                    hashedShard: archaeologists[i].hashedShard,
+                    unencryptedShard: ""
                 });
 
             // Stores each archaeologist's bounty, digging fees, and unencrypted
@@ -285,7 +286,7 @@ contract EmbalmerFacet {
             // archaeologist on the sarcophagus and run ecrecover to see if
             // there is a match. This is much more efficient.
             if (
-                !LibUtils.archaeologistExists(
+                !LibUtils.archaeologistExistsOnSarc(
                     identifier,
                     archaeologistSignatures[i].account
                 )

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -420,11 +420,8 @@ contract EmbalmerFacet {
 
         for (uint256 i = 0; i < archaeologistAddresses.length; i++) {
             // Get the archaeolgist's fee data
-            LibTypes.ArchaeologistStorage
-                memory archaeologistData = getArchaeologist(
-                    identifier,
-                    archaeologistAddresses[i]
-                );
+            LibTypes.ArchaeologistStorage memory archaeologistData = LibUtils
+                .getArchaeologist(identifier, archaeologistAddresses[i]);
 
             // Transfer the archaeologist's digging fee allocation to the archaeologist
             s.sarcoToken.transfer(
@@ -557,11 +554,8 @@ contract EmbalmerFacet {
             // Unlock the archaeologist's cursed bond
             LibBonds.freeArchaeologist(identifier, archaeologistAddresses[i]);
 
-            LibTypes.ArchaeologistStorage
-                memory archaeologistData = getArchaeologist(
-                    identifier,
-                    archaeologistAddresses[i]
-                );
+            LibTypes.ArchaeologistStorage memory archaeologistData = LibUtils
+                .getArchaeologist(identifier, archaeologistAddresses[i]);
 
             // Transfer the digging fees to the archaeologist
             s.sarcoToken.transfer(
@@ -580,18 +574,5 @@ contract EmbalmerFacet {
         emit LibEvents.BurySarcophagus(identifier);
 
         return true;
-    }
-
-    /// @notice Gets an archaeologist given the sarcophagus identifier and the
-    /// archaeologist's address.
-    /// @param identifier the identifier of the sarcophagus
-    /// @param archaeologist the address of the archaeologist
-    /// @return The archaeologist
-    function getArchaeologist(bytes32 identifier, address archaeologist)
-        private
-        view
-        returns (LibTypes.ArchaeologistStorage memory)
-    {
-        return s.sarcophagusArchaeologists[identifier][archaeologist];
     }
 }

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -7,6 +7,8 @@ pragma solidity ^0.8.13;
  * uses.
  */
 library LibErrors {
+    error ArchaeologistAlreadyUnwrapped(address archaeologist);
+
     error ArchaeologistListNotUnique(address[] archaeologists);
 
     error ArchaeologistNotOnSarcophagus(address archaeologist);
@@ -47,4 +49,17 @@ library LibErrors {
     );
 
     error SignatureListNotUnique();
+
+    error TooEarlyToUnwrap(uint256 resurrectionTime, uint256 currentTime);
+
+    error TooLateToUnwrap(
+        uint256 resurrectionTime,
+        uint256 resurrectionWindow,
+        uint256 currentTime
+    );
+
+    error UnencryptedShardHashMismatch(
+        bytes unencryptedShard,
+        bytes32 hashedShard
+    );
 }

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -23,6 +23,8 @@ library LibErrors {
 
     error MinShardsZero();
 
+    error NewResurrectionTimeInPast(uint256 newResurrectionTime);
+
     error NoArchaeologistsProvided();
 
     error NotEnoughCursedBond(uint256 cursedBond, uint256 amount);

--- a/contracts/libraries/LibEvents.sol
+++ b/contracts/libraries/LibEvents.sol
@@ -65,11 +65,7 @@ library LibEvents {
         uint256 resurrectionWindow
     );
 
-    event UnwrapSarcophagus(
-        string assetId,
-        bytes32 indexed identifier,
-        bytes32 privatekey
-    );
+    event UnwrapSarcophagus(bytes32 indexed identifier, bytes unencryptedShard);
 
     event AccuseArchaeologist(
         bytes32 indexed identifier,

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -62,6 +62,7 @@ library LibTypes {
         uint256 diggingFee;
         uint256 bounty;
         bytes32 hashedShard;
+        bytes unencryptedShard;
     }
 
     // The ArchaeologistStorage struct could be contained in this Sarcophagus

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -56,6 +56,19 @@ library LibUtils {
         require(bytes(newAssetId).length > 0, "assetId must not have 0 length");
     }
 
+    function archaeologistUnwrappedCheck(
+        bytes32 identifier,
+        address archaeologist
+    ) internal view {
+        if (
+            getArchaeologist(identifier, archaeologist)
+                .unencryptedShard
+                .length > 0
+        ) {
+            revert LibErrors.ArchaeologistAlreadyUnwrapped(archaeologist);
+        }
+    }
+
     /**
      * @notice Given some bytes32 data, a signature, and an account, verify that the
      * identifier was signed by the account.
@@ -187,20 +200,25 @@ library LibUtils {
      * (relative, i.e. "30 minutes")
      */
     function unwrapTime(uint256 resurrectionTime, uint256 resurrectionWindow)
-        public
+        internal
         view
     {
         // revert if too early
-        require(
-            resurrectionTime <= block.timestamp,
-            "it's not time to unwrap the sarcophagus"
-        );
+        if (resurrectionTime > block.timestamp) {
+            revert LibErrors.TooEarlyToUnwrap(
+                resurrectionTime,
+                block.timestamp
+            );
+        }
 
         // revert if too late
-        require(
-            resurrectionTime + resurrectionWindow >= block.timestamp,
-            "the resurrection window has expired"
-        );
+        if (resurrectionTime + resurrectionWindow < block.timestamp) {
+            revert LibErrors.TooLateToUnwrap(
+                resurrectionTime,
+                resurrectionWindow,
+                block.timestamp
+            );
+        }
     }
 
     /**
@@ -212,38 +230,6 @@ library LibUtils {
             account == msg.sender,
             "sarcophagus cannot be updated by account"
         );
-    }
-
-    /**
-     * @notice Reverts if the input resurrection time, digging fee, or bounty
-     * don't fit within the other given maximum and minimum values
-     * @param resurrectionTime the resurrection time to check
-     * @param diggingFee the digging fee to check
-     * @param bounty the bounty to check
-     * @param maximumResurrectionTime the maximum resurrection time to check
-     * against, in relative terms (i.e. "1 year" is 31536000 (seconds))
-     * @param minimumDiggingFee the minimum digging fee to check against
-     * @param minimumBounty the minimum bounty to check against
-     */
-    function withinArchaeologistLimits(
-        uint256 resurrectionTime,
-        uint256 diggingFee,
-        uint256 bounty,
-        uint256 maximumResurrectionTime,
-        uint256 minimumDiggingFee,
-        uint256 minimumBounty
-    ) public view {
-        // revert if the given resurrection time is too far in the future
-        require(
-            resurrectionTime <= block.timestamp + maximumResurrectionTime,
-            "resurrection time too far in the future"
-        );
-
-        // revert if the given digging fee is too low
-        require(diggingFee >= minimumDiggingFee, "digging fee is too low");
-
-        // revert if the given bounty is too low
-        require(bounty >= minimumBounty, "bounty is too low");
     }
 
     /// @notice Checks if the archaeologist exists on the sarcophagus.

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -236,11 +236,10 @@ library LibUtils {
     /// @param identifier the identifier of the sarcophagus
     /// @param archaeologist the address of the archaeologist
     /// @return The boolean true if the archaeologist exists on the sarcophagus
-    function archaeologistExists(bytes32 identifier, address archaeologist)
-        internal
-        view
-        returns (bool)
-    {
+    function archaeologistExistsOnSarc(
+        bytes32 identifier,
+        address archaeologist
+    ) internal view returns (bool) {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
         // If the hashedShard on an archaeologist is 0 (which is its default

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -264,4 +264,19 @@ library LibUtils {
             .sarcophagusArchaeologists[identifier][archaeologist].hashedShard !=
             0;
     }
+
+    /// @notice Gets an archaeologist given the sarcophagus identifier and the
+    /// archaeologist's address.
+    /// @param identifier the identifier of the sarcophagus
+    /// @param archaeologist the address of the archaeologist
+    /// @return The archaeologist
+    function getArchaeologist(bytes32 identifier, address archaeologist)
+        internal
+        view
+        returns (LibTypes.ArchaeologistStorage memory)
+    {
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        return s.sarcophagusArchaeologists[identifier][archaeologist];
+    }
 }

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
+import "../storage/LibAppStorage.sol";
 import "../libraries/LibTypes.sol";
 import {LibErrors} from "../libraries/LibErrors.sol";
 import {LibDiamond} from "../diamond/libraries/LibDiamond.sol";
@@ -243,5 +244,24 @@ library LibUtils {
 
         // revert if the given bounty is too low
         require(bounty >= minimumBounty, "bounty is too low");
+    }
+
+    /// @notice Checks if the archaeologist exists on the sarcophagus.
+    /// @param identifier the identifier of the sarcophagus
+    /// @param archaeologist the address of the archaeologist
+    /// @return The boolean true if the archaeologist exists on the sarcophagus
+    function archaeologistExists(bytes32 identifier, address archaeologist)
+        internal
+        view
+        returns (bool)
+    {
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        // If the hashedShard on an archaeologist is 0 (which is its default
+        // value), then the archaeologist doesn't exist on the sarcophagus
+        return
+            s
+            .sarcophagusArchaeologists[identifier][archaeologist].hashedShard !=
+            0;
     }
 }

--- a/test/facets/archaeologist-facet.spec.ts
+++ b/test/facets/archaeologist-facet.spec.ts
@@ -407,9 +407,6 @@ describe("Contract: ArchaeologistFacet", () => {
       it("should store the unencrypted shard on the contract", async () => {
         // TODO: Write a view method to get the sarcophagus state
       });
-      it("should set the state of the sarcophagus to done", async () => {
-        // TODO: Write a view method to get the sarcophagus state
-      });
       it("should free up the archaeologist's cursed bond", async () => {
         // Get the cursed bond amount of the first archaeologist before initialize
         const cursedBondAmountBefore = await archaeologistFacet.getCursedBond(

--- a/test/facets/archaeologist-facet.spec.ts
+++ b/test/facets/archaeologist-facet.spec.ts
@@ -1,10 +1,20 @@
-import "@nomiclabs/hardhat-waffle";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import "@nomiclabs/hardhat-waffle";
 import { expect } from "chai";
-import { BigNumber } from "ethers";
+import { BigNumber, Signature } from "ethers";
 import { ethers } from "hardhat";
 import { deployDiamond } from "../../scripts/deploy-diamond";
-import { ArchaeologistFacet, SarcoTokenMock } from "../../typechain";
+import {
+  ArchaeologistFacet,
+  EmbalmerFacet,
+  SarcoTokenMock,
+} from "../../typechain";
+import { SignatureWithAccount } from "../../types";
+import {
+  increaseNextBlockTimestamp,
+  setupArchaeologists,
+  sign,
+} from "../utils/helpers";
 
 describe("Contract: ArchaeologistFacet", () => {
   let archaeologistFacet: ArchaeologistFacet;
@@ -239,6 +249,455 @@ describe("Contract: ArchaeologistFacet", () => {
           sarcoToken.address
         )
       ).to.be.revertedWith("SenderNotArch");
+    });
+  });
+
+  describe("unwrapSarcophagus()", () => {
+    let sarcoToken: SarcoTokenMock;
+    let arweaveSignature: Signature;
+    let diamondAddress: string;
+    let archaeologists: SignerWithAddress[];
+    let signers: SignerWithAddress[];
+    let embalmer: SignerWithAddress;
+    let arweaveArchaeologist: SignerWithAddress;
+    let recipient: SignerWithAddress;
+    let embalmerFacet: EmbalmerFacet;
+
+    const arweaveTxId = "someArweaveTxId";
+
+    // Define an arcaeologist fees object to be used in any test that needs it
+    const archaeologistsFees = [
+      {
+        storageFee: 20,
+        diggingFee: 10,
+        bounty: 100,
+      },
+      {
+        storageFee: 25,
+        diggingFee: 8,
+        bounty: 112,
+      },
+      {
+        storageFee: 21,
+        diggingFee: 9,
+        bounty: 105,
+      },
+    ];
+
+    // Set up the signers for the tests
+    before(async () => {
+      signers = await ethers.getSigners();
+
+      // Set some roles to be used in the tests
+      embalmer = signers[0];
+      archaeologists = [signers[1], signers[2], signers[3]];
+      arweaveArchaeologist = signers[1];
+      recipient = signers[4];
+    });
+
+    // Deploy the contracts
+    before(async () => {
+      ({ diamondAddress, sarcoToken } = await deployDiamond());
+
+      embalmerFacet = await ethers.getContractAt(
+        "EmbalmerFacet",
+        diamondAddress
+      );
+
+      // Get the archaeologistFacet so we can add some free bond for the archaeologists
+      archaeologistFacet = await ethers.getContractAt(
+        "ArchaeologistFacet",
+        diamondAddress
+      );
+
+      await setupArchaeologists(
+        archaeologistFacet,
+        archaeologists,
+        diamondAddress,
+        embalmer,
+        sarcoToken
+      );
+
+      arweaveSignature = await sign(
+        arweaveArchaeologist,
+        arweaveTxId,
+        "string"
+      );
+    });
+
+    const initializeSarcophagus = async (
+      unhashedId: string
+    ): Promise<string> => {
+      const name = "New Sarcophagus";
+      const identifier = ethers.utils.solidityKeccak256(
+        ["string"],
+        [unhashedId]
+      );
+
+      // Define archaeologist objects to be passed into the sarcophagus.
+      // Since the contract doesn't care what the value of the shard is, just
+      // hash the archaeologist's address. In practice we would not be hashing
+      // an address, of course, but a long string representing the shard.
+      const archaeologistObjects = archaeologists.map((a, i) => ({
+        archAddress: a.address,
+        storageFee: BigNumber.from(archaeologistsFees[i].storageFee),
+        diggingFee: BigNumber.from(archaeologistsFees[i].diggingFee),
+        bounty: BigNumber.from(archaeologistsFees[i].bounty),
+        hashedShard: ethers.utils.solidityKeccak256(["string"], [a.address]),
+      }));
+
+      const canBeTransferred = true;
+
+      // Set a resurrection time 1 week in the future
+      const resurrectionTime =
+        (await ethers.provider.getBlock("latest")).timestamp + 604800;
+
+      const minShards = 3;
+
+      // Create a sarcophagus as the embalmer
+      await embalmerFacet
+        .connect(embalmer)
+        .initializeSarcophagus(
+          name,
+          identifier,
+          archaeologistObjects,
+          arweaveArchaeologist.address,
+          recipient.address,
+          resurrectionTime,
+          canBeTransferred,
+          minShards
+        );
+
+      return identifier;
+    };
+
+    const finalizeSarcophagus = async (identifier: string) => {
+      const signatures: SignatureWithAccount[] = [];
+
+      for (const archaeologist of archaeologists) {
+        // Sign a message and add to signatures. Only sign if the archaeologist
+        // is not the arweave archaeologist
+        if (archaeologist.address !== arweaveArchaeologist.address) {
+          const signature = await sign(archaeologist, identifier, "bytes32");
+
+          signatures.push(
+            Object.assign(signature, { account: archaeologist.address })
+          );
+        }
+      }
+
+      const arweaveSignature = await sign(
+        arweaveArchaeologist,
+        arweaveTxId,
+        "string"
+      );
+
+      // Finalize the sarcophagus
+      await embalmerFacet
+        .connect(embalmer)
+        .finalizeSarcophagus(
+          identifier,
+          signatures,
+          arweaveSignature,
+          arweaveTxId
+        );
+    };
+
+    context("Successful unwrap", () => {
+      it("should store the unencrypted shard on the contract", async () => {
+        // TODO: Write a view method to get the sarcophagus state
+      });
+      it("should set the state of the sarcophagus to done", async () => {
+        // TODO: Write a view method to get the sarcophagus state
+      });
+      it("should free up the archaeologist's cursed bond", async () => {
+        // Get the cursed bond amount of the first archaeologist before initialize
+        const cursedBondAmountBefore = await archaeologistFacet.getCursedBond(
+          archaeologists[0].address
+        );
+
+        // Initialize the sarcophagusk
+        const identifier = await initializeSarcophagus(
+          "shouldFreeUpArchsCursedBond"
+        );
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        await archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        // Get the cursed bond amount of the first archaeologist after unwrapping
+        const cursedBondAmountAfter = await archaeologistFacet.getCursedBond(
+          archaeologists[0].address
+        );
+
+        // await ethers.provider.send("evm_increaseTime", [-604801]);
+
+        // Check that the cursed bond amount before intialize and after unwrap are the same amount.
+        expect(cursedBondAmountAfter).to.equal(cursedBondAmountBefore);
+      });
+
+      it("should add this sarcophagus to the archaeologist's successful sarcophaguses", async () => {
+        // TODO: Write a view method to get the sarcophagus state
+      });
+
+      it("should transfer the digging fee and bounty to the archaeologist", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus(
+          "shouldTransferFeesToArch"
+        );
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Calculate the digging fee and bounty for the first archaeologist
+        const totalFees = BigNumber.from(
+          archaeologistsFees[0].diggingFee + archaeologistsFees[0].bounty
+        );
+        // Get the sarco balance of the first archaeologist before unwrap
+        const sarcoBalanceBefore = await sarcoToken.balanceOf(
+          archaeologists[0].address
+        );
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        await archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        // Get the sarco balance of the first archaeologist after unwrap
+        const sarcoBalanceAfter = await sarcoToken.balanceOf(
+          archaeologists[0].address
+        );
+
+        // Check that the difference between the before and after balances is
+        // equal to the total fees
+        expect(sarcoBalanceAfter.sub(sarcoBalanceBefore)).to.equal(totalFees);
+      });
+
+      it("should emit an event", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus("shouldEmitAnEvent");
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        const tx = await archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        const receipt = await tx.wait();
+
+        const events = receipt.events!;
+        expect(events).to.not.be.undefined;
+
+        // Check that the list of events includes an event that has an address
+        // matching the embalmerFacet address
+        expect(
+          events.some((event) => event.address === archaeologistFacet.address)
+        ).to.be.true;
+      });
+    });
+
+    context("Failed unwrap", () => {
+      it("should revert if the sarcophagus does not exist", async () => {
+        const falseIdentifier = ethers.utils.solidityKeccak256(
+          ["string"],
+          ["falseIdentifier"]
+        );
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(falseIdentifier, Buffer.from(unencryptedShard));
+
+        expect(tx).to.be.revertedWith("SarcophagusDoesNotExist");
+      });
+
+      it("should revert if the sender is not an archaeologist on this sarcophagus", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus(
+          "senderNotArchaeologist"
+        );
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(embalmer)
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        expect(tx).to.be.revertedWith("SenderNotArchaeologist");
+      });
+
+      it("should revert if unwrap is called before the resurrection time has passed", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus("calledTooEarly");
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        expect(tx).to.be.revertedWith("TooEarlyToUnwrap");
+      });
+
+      it("should revert if unwrap is called after the resurrection window has expired", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus("calledTooLate");
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 2 weeks in the future
+        await increaseNextBlockTimestamp(604800 * 2);
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        expect(tx).to.be.revertedWith("TooLateToUnwrap");
+      });
+
+      it("should revert if this archaeologist has already unwrapped this sarcophagus", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus("archAlreadyUnwrapped");
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        await archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        expect(tx).to.be.revertedWith("ArchaeologistAlreadyUnwrapped");
+      });
+
+      it("should revert if the hash of the unencrypted shard does not match the hashed shard stored on the sarcophagus", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus("shardMismatch");
+
+        // Finalize the sarcophagus
+        await finalizeSarcophagus(identifier);
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from("somethingElse"));
+
+        expect(tx).to.be.revertedWith("UnencryptedShardHashMismatch");
+      });
+
+      it("should revert if the sarcophagus is not finalized", async () => {
+        // Initialize the sarcophagus
+        const identifier = await initializeSarcophagus("sarcNotFinalized");
+
+        // Earlier during initialize we used each archaeologist's address as the
+        // unencrypted shard. In practice this will obviously not be the
+        // archaeologist's address. The contract doesn't care what the
+        // unencrypted shard is.
+        const unencryptedShard = archaeologists[0].address;
+
+        // Set the evm timestamp of the next block to be 1 week and 1 second in
+        // the future
+        await increaseNextBlockTimestamp(604801);
+
+        // Have archaeologist unwrap
+        const tx = archaeologistFacet
+          .connect(archaeologists[0])
+          .unwrapSarcophagus(identifier, Buffer.from(unencryptedShard));
+
+        expect(tx).to.be.revertedWith("SarcophagusNotFinalized");
+      });
     });
   });
 });

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -1223,7 +1223,7 @@ describe("Contract: EmbalmerFacet", () => {
           newResurrectionTime
         );
 
-        expect(tx).to.be.revertedWith("ResurrectionTimeInPast");
+        expect(tx).to.be.revertedWith("NewResurrectionTimeInPast");
       });
     });
   });

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { Signature } from "ethers";
+import { BigNumber, Signature } from "ethers";
 import { ethers } from "hardhat";
+import { ArchaeologistFacet, SarcoTokenMock } from "../../typechain";
 
 /**
  * Signs a message as any EVM compatible type and returns the signature and the
@@ -23,3 +24,59 @@ export async function sign(
   const signature = await signer.signMessage(dataHashBytes);
   return ethers.utils.splitSignature(signature);
 }
+
+/**
+ * Increase the timestamp of the next block by a given number of seconds.
+ *
+ * @param sec The number of seconds to increase the next block by
+ */
+export const increaseNextBlockTimestamp = async (
+  sec: number
+): Promise<void> => {
+  await ethers.provider.send("evm_setNextBlockTimestamp", [
+    (await ethers.provider.getBlock("latest")).timestamp + sec,
+  ]);
+};
+
+/**
+ * Sets up the archaeologists for the tests
+ *
+ * @param archaeologistFacet The archaeologist facet
+ * @param archaeologists The list of archaeologists
+ * @param diamondAddress The address of the diamond
+ * @param embalmer The embalmer
+ * @param sarcoToken The sarco token
+ */
+export const setupArchaeologists = async (
+  archaeologistFacet: ArchaeologistFacet,
+  archaeologists: SignerWithAddress[],
+  diamondAddress: string,
+  embalmer: SignerWithAddress,
+  sarcoToken: SarcoTokenMock
+): Promise<void> => {
+  // Approve the embalmer on the sarco token so transferFrom will work
+  await sarcoToken
+    .connect(embalmer)
+    .approve(diamondAddress, ethers.constants.MaxUint256);
+
+  for (const archaeologist of archaeologists) {
+    // Transfer 10,000 sarco tokens to each archaeologist to be put into free
+    // bond
+    await sarcoToken.transfer(archaeologist.address, BigNumber.from(10_000));
+
+    // Approve the archaeologist on the sarco token so transferFrom will work
+    await sarcoToken
+      .connect(archaeologist)
+      .approve(diamondAddress, ethers.constants.MaxUint256);
+
+    // Deposit some free bond to the contract so initializeSarcophagus will
+    // work
+    await archaeologistFacet
+      .connect(archaeologist)
+      .depositFreeBond(
+        archaeologist.address,
+        BigNumber.from("5000"),
+        sarcoToken.address
+      );
+  }
+};


### PR DESCRIPTION
# Unwrap Sarcophagus

Adds the `unwrapSarcophagus()` function to `ArchaeologistFacet.sol`. 

### Notes
- The tests don't use Shamir Secret Sharing since the contracts don't care at all about the contents of the unencrypted shards. The contract only checks that the shards passed in during initialize match the shards being passed in during unwrap.