### PR TITLE
Pay out non naughty archaeologists

### DIFF
--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -282,13 +282,6 @@ contract ThirdPartyFacet {
         // transfer the other half of the cursed bond to the transaction caller
         s.sarcoToken.transfer(paymentAddress, halfToSender);
 
-        // This cannot be (easily) done here.
-        // Instead, it's done as defaulters are being aggregated in clean function
-        // LibBonds.decreaseCursedBond(
-        //     sarc.archaeologist,
-        //     sarc.currentCursedBond
-        // );
-
         return (halfToSender, halfToEmbalmer);
     }
 

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -126,7 +126,6 @@ contract ThirdPartyFacet {
             revert LibErrors.NotEnoughProof();
         }
 
-        // TODO not in use now, but might be useful for filtering out unaccused archs for reimbursement.
         address[] memory accusedArchAddresses = new address[](
             unencryptedShards.length
         );
@@ -166,6 +165,30 @@ contract ThirdPartyFacet {
             }
         }
 
+        // At this point, we need to filter out unaccused archs in order to reimburse them.
+        address[] memory sarcoArchsAddresses = s
+            .sarcophaguses[sarcoId]
+            .archaeologists;
+
+        for (uint256 i = 0; i < sarcoArchsAddresses.length; i++) {
+            // Need to check each archaeologist address on the sarcophagus
+            bool isUnaccused = true;
+
+            for (uint256 j = 0; j < accusedArchAddresses.length; j++) {
+                // For each arch address, if found in accusedArchAddresses,
+                // then don't add to unaccusedArchsAddresses
+                if (sarcoArchsAddresses[i] == accusedArchAddresses[j]) {
+                    isUnaccused = false;
+                    break;
+                }
+            }
+
+            // If this arch address wasn't in the accused list, reimburse it
+            if (isUnaccused) {
+                _reimburseArch(sarcoId, sarcoArchsAddresses[i]);
+            }
+        }
+
         (
             uint256 accuserBondReward,
             uint256 embalmerBondReward
@@ -176,8 +199,6 @@ contract ThirdPartyFacet {
                 diggingFeesToBeDistributed,
                 bountyToBeDistributed
             );
-
-        // _reimburseArchs(archs);
 
         sarco.state = LibTypes.SarcophagusState.Done;
 
@@ -190,8 +211,28 @@ contract ThirdPartyFacet {
     }
 
     /**
+     * @notice Transfers the value of the cursed bond of the archaeologist back to them, and un-curses their bond.
+     * @param sarcoId The identifier of the sarcophagus for which the bonds were cursed
+     * @param arch Address of the archaeologist to reimburse
+     */
+    function _reimburseArch(bytes32 sarcoId, address arch) private {
+        LibTypes.ArchaeologistStorage storage goodArch = s
+            .sarcophagusArchaeologists[sarcoId][arch];
+
+        uint256 cursedBond = LibBonds.calculateCursedBond(
+            goodArch.diggingFee,
+            goodArch.bounty
+        );
+
+        s.sarcoToken.transfer(arch, cursedBond);
+        LibBonds.freeArchaeologist(sarcoId, arch);
+    }
+
+    /**
      * @notice After a sarcophagus has been successfully accused, transfers the value
      * of the cursed bonds of the archs back to them, and un-curses their bonds.
+     * @dev not using this in accuse because it'd involve yet another loop.
+     * Instead, _reimburseArch will run on each unaccused archaeologist that's found.
      * @param sarcoId The identifier of the sarcophagus for which the bonds were cursed
      * @param archs The archaeologists to reimburse
      * @param amounts amounts of sarco tokens to transfer to archaeologists. Should be in same order
@@ -203,7 +244,7 @@ contract ThirdPartyFacet {
         uint256[] memory amounts
     ) private {
         for (uint256 i = 0; i < archs.length; i++) {
-            s.sarcoToken.transfer(archs[i], amounts[i]); // What account will this transfer from?!
+            s.sarcoToken.transfer(archs[i], amounts[i]);
             LibBonds.freeArchaeologist(sarcoId, archs[i]);
         }
     }

--- a/test/facets/archaeologist-facet.spec.ts
+++ b/test/facets/archaeologist-facet.spec.ts
@@ -11,7 +11,7 @@ import {
   SarcoTokenMock,
   ViewStateFacet,
 } from "../../typechain";
-import { SarcophagusState, SignatureWithAccount } from "../../types";
+import { SignatureWithAccount } from "../../types";
 import {
   increaseNextBlockTimestamp,
   setupArchaeologists,

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../../typechain";
 import { EmbalmerFacet } from "../../typechain/EmbalmerFacet";
 import { SarcophagusState, SignatureWithAccount } from "../../types";
-import { sign } from "../utils/helpers";
+import { calculateCursedBond, sign } from "../utils/helpers";
 
 describe("Contract: EmbalmerFacet", () => {
   // Define a resurrrection time one week in the future
@@ -689,9 +689,10 @@ describe("Contract: EmbalmerFacet", () => {
         );
 
         // TODO: Modify this when the calculateCursedBond method changes in the contract
-        const firstArchaeologistCursedBond =
-          archaeologistsFees[arweaveArchaeologistIndex].bounty +
-          archaeologistsFees[arweaveArchaeologistIndex].diggingFee;
+        const firstArchaeologistCursedBond = calculateCursedBond(
+          BigNumber.from(archaeologistsFees[arweaveArchaeologistIndex].diggingFee),
+          BigNumber.from(archaeologistsFees[arweaveArchaeologistIndex].bounty)
+        );
 
         expect(freeBondBefore.sub(freeBondAfter)).to.equal(
           BigNumber.from(firstArchaeologistCursedBond)

--- a/test/facets/third-party-facet.spec.ts
+++ b/test/facets/third-party-facet.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "../../typechain";
 import { BytesLike, formatBytes32String } from "ethers/lib/utils";
 import time from "../utils/time";
-import { sign } from "../utils/helpers";
+import { calculateCursedBond, sign } from "../utils/helpers";
 
 describe.only("Contract: ThirdPartyFacet", () => {
   let archaeologistFacet: ArchaeologistFacet;
@@ -278,7 +278,7 @@ describe.only("Contract: ThirdPartyFacet", () => {
         .add(arch2.bounty)
         .add(arch3.bounty);
 
-      const cursedBond = totalDiggingFees.add(totalBounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
+      const cursedBond = calculateCursedBond(totalDiggingFees, totalBounty);
       const toEmbalmer = cursedBond.div(2);
       const toCleaner = cursedBond.sub(toEmbalmer);
 
@@ -483,7 +483,7 @@ describe.only("Contract: ThirdPartyFacet", () => {
         const totalDiggingFees = arch1.diggingFee.add(arch2.diggingFee);
         const totalBounty = arch1.bounty.add(arch2.bounty);
 
-        const cursedBond = totalDiggingFees.add(totalBounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
+        const cursedBond = calculateCursedBond(totalDiggingFees, totalBounty);
         const toEmbalmer = cursedBond.div(2);
         const toAccuser = cursedBond.sub(toEmbalmer);
 
@@ -565,8 +565,8 @@ describe.only("Contract: ThirdPartyFacet", () => {
         const arch1 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, arweaveAchaeologist.address);
         const arch2 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, unaccusedArchaeologist.address);
 
-        const cursedBond1 = arch1.diggingFee.add(arch1.bounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
-        const cursedBond2 = arch2.diggingFee.add(arch2.bounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
+        const cursedBond1 = calculateCursedBond(arch1.diggingFee, arch1.bounty);
+        const cursedBond2 = calculateCursedBond(arch2.diggingFee, arch2.bounty);
 
         const unaccusedArchaeologist1BalAfter = await sarcoToken.balanceOf(arweaveAchaeologist.address);
         const unaccusedArchaeologist2BalAfter = await sarcoToken.balanceOf(unaccusedArchaeologist.address);

--- a/test/facets/third-party-facet.spec.ts
+++ b/test/facets/third-party-facet.spec.ts
@@ -466,38 +466,37 @@ describe("Contract: ThirdPartyFacet", () => {
       );
 
       it(
-        "Should distribute the bounties and digging fees of unaccused archaeologists back to them, and un-curse their associated bonds"
-        // , async () => {
-        //     const unaccusedArchaeologist1BalBefore = await sarcoToken.balanceOf(arweaveAchaeologist.address);
-        //     const unaccusedArchaeologist2BalBefore = await sarcoToken.balanceOf(unaccusedArchaeologist.address);
+        "Should distribute the bounties and digging fees of unaccused archaeologists back to them, and un-curse their associated bonds", async () => {
+          const unaccusedArchaeologist1BalBefore = await sarcoToken.balanceOf(arweaveAchaeologist.address);
+          const unaccusedArchaeologist2BalBefore = await sarcoToken.balanceOf(unaccusedArchaeologist.address);
 
-        //     const cursedBond1Before = await archaeologistFacet.getCursedBond(arweaveAchaeologist.address);
-        //     const cursedBond2Before = await archaeologistFacet.getCursedBond(unaccusedArchaeologist.address);
+          const cursedBond1Before = await viewStateFacet.getCursedBond(arweaveAchaeologist.address);
+          const cursedBond2Before = await viewStateFacet.getCursedBond(unaccusedArchaeologist.address);
 
-        //     const tx = await thirdPartyFacet.connect(thirdParty).accuse(sarcoId, unencryptedShards.slice(0, 2), paymentAccount.address);
-        //     await tx.wait();
+          const tx = await thirdPartyFacet.connect(thirdParty).accuse(sarcoId, unencryptedShards.slice(0, 2), paymentAccount.address);
+          await tx.wait();
 
-        //     // Set up amounts that should have been transferred to unaccused archaeologists
-        //     const arch1 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, arweaveAchaeologist.address);
-        //     const arch2 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, unaccusedArchaeologist.address);
+          // Set up amounts that should have been transferred to unaccused archaeologists
+          const arch1 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, arweaveAchaeologist.address);
+          const arch2 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, unaccusedArchaeologist.address);
 
-        //     const cursedBond1 = arch1.diggingFee.add(arch1.bounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
-        //     const cursedBond2 = arch2.diggingFee.add(arch2.bounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
+          const cursedBond1 = arch1.diggingFee.add(arch1.bounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
+          const cursedBond2 = arch2.diggingFee.add(arch2.bounty); // TODO: update if calculate cursed bond algorithm changes (need helper util for this, or read this from contract)
 
-        //     const unaccusedArchaeologist1BalAfter = await sarcoToken.balanceOf(arweaveAchaeologist.address);
-        //     const unaccusedArchaeologist2BalAfter = await sarcoToken.balanceOf(unaccusedArchaeologist.address);
+          const unaccusedArchaeologist1BalAfter = await sarcoToken.balanceOf(arweaveAchaeologist.address);
+          const unaccusedArchaeologist2BalAfter = await sarcoToken.balanceOf(unaccusedArchaeologist.address);
 
-        //     const cursedBond1After = await archaeologistFacet.getCursedBond(arweaveAchaeologist.address);
-        //     const cursedBond2After = await archaeologistFacet.getCursedBond(unaccusedArchaeologist.address);
+          const cursedBond1After = await viewStateFacet.getCursedBond(arweaveAchaeologist.address);
+          const cursedBond2After = await viewStateFacet.getCursedBond(unaccusedArchaeologist.address);
 
-        //     // Check that unaccused archaeologists now have balances that includes the amount that should have been transferred to them
-        //     expect(unaccusedArchaeologist1BalAfter.gte(unaccusedArchaeologist1BalBefore.add(cursedBond1))).to.be.true;
-        //     expect(unaccusedArchaeologist2BalAfter.gte(unaccusedArchaeologist2BalBefore.add(cursedBond2))).to.be.true;
+          // Check that unaccused archaeologists now have balances that includes the amount that should have been transferred to them
+          expect(unaccusedArchaeologist1BalAfter.gte(unaccusedArchaeologist1BalBefore.add(cursedBond1))).to.be.true;
+          expect(unaccusedArchaeologist2BalAfter.gte(unaccusedArchaeologist2BalBefore.add(cursedBond2))).to.be.true;
 
-        //     // Check that unaccused archaeologists' cursed bonds have been un-cursed
-        //     expect(cursedBond1Before.gte(cursedBond1After)).to.be.true;
-        //     expect(cursedBond2Before.gte(cursedBond2After)).to.be.true;
-        // }
+          // Check that unaccused archaeologists' cursed bonds have been un-cursed
+          expect(cursedBond1Before.gte(cursedBond1After)).to.be.true;
+          expect(cursedBond2Before.gte(cursedBond2After)).to.be.true;
+        }
       );
 
       it(

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -76,3 +76,6 @@ export const setupArchaeologists = async (
       .depositFreeBond(BigNumber.from("5000"));
   }
 };
+
+// TODO: update if calculate cursed bond algorithm changes (or possibly read this from contract instead?)
+export const calculateCursedBond = (diggingFee: BigNumber, bounty: BigNumber) => diggingFee.add(bounty);


### PR DESCRIPTION
I ended up having to use another loop to do this, and that loop contains a nested loop. 

The outer loop iterates through all archs bonded to the sarco; the inner one iterates through just the accused archs, with the possibility of terminating prematurely.

Also, reimbursement is happening right as non-naughty archs are found, to avoid yet another loop if I were to merely track their addresses in another array.