### PR TITLE
30 update transfer rewards

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -39,6 +39,17 @@ contract ArchaeologistFacet {
         emit LibEvents.WithdrawFreeBond(msg.sender, amount);
     }
 
+    /// @notice Withdraws froms an archaeologist's reward pool
+    /// @param amount The amount to withdraw
+    function withdrawReward(uint256 amount) external {
+        _decreaseRewardPool(amount);
+
+        // Transfer the amount of sarcoToken to the archaeologist
+        s.sarcoToken.transfer(msg.sender, amount);
+
+        emit LibEvents.WithdrawReward(msg.sender, amount);
+    }
+
     /// @notice Unwraps the sarcophagus.
     /// @dev Verifies that the unencrypted shard matches the hashedShard stored
     /// on chain and pays the archaeologist.
@@ -216,5 +227,29 @@ contract ArchaeologistFacet {
             oldArchaeologist,
             msg.sender
         );
+    }
+
+    /// @notice Decreases the amount stored in the archaeologistRewards mapping for an
+    /// archaeologist. Reverts if the archaeologist's reward is lower than
+    /// the amount. Called on reward withdraw.
+    /// @param amount The amount to decrease the reward by
+    function _decreaseRewardPool(uint256 amount) private {
+        // Revert if the amount is greater than the current reward
+        if (amount > s.archaeologistRewards[msg.sender]) {
+            revert LibErrors.NotEnoughReward(
+                s.archaeologistRewards[msg.sender],
+                amount
+            );
+        }
+
+        // Decrease the free bond amount
+        s.archaeologistRewards[msg.sender] -= amount;
+    }
+
+    /// @notice Increases the amount stored in the archaeologistRewards mapping for an
+    /// archaeologist.
+    /// @param amount The amount to increase the reward by
+    function _increaseRewardPool(uint256 amount) private {
+        s.archaeologistRewards[msg.sender] += amount;
     }
 }

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -348,9 +348,12 @@ contract EmbalmerFacet {
         // being populated indirectly designates the sarcophagus as finalized.
         s.sarcophaguses[identifier].arweaveTxIds.push(arweaveTxId);
 
-        // Transfer the storage fee to the arweave archaeologist after setting
-        // the arweave transaction id.
-        s.sarcoToken.transfer(
+        // Transfer the storage fee to the arweave archaeologist's reward pool
+        // after setting the arweave transaction id.
+        // TODO: Discuss, confirm if this is okay:
+        // Is there value in directly transferring the storage fee to the
+        // archaeologist on finalise?
+        LibRewards.increaseRewardPool(
             s.sarcophaguses[identifier].arweaveArchaeologist,
             s.sarcophaguses[identifier].storageFee
         );

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -6,6 +6,7 @@ import "../libraries/LibTypes.sol";
 import "../libraries/LibEvents.sol";
 import {LibErrors} from "../libraries/LibErrors.sol";
 import {LibBonds} from "../libraries/LibBonds.sol";
+import {LibRewards} from "../libraries/LibRewards.sol";
 import {LibUtils} from "../libraries/LibUtils.sol";
 import {AppStorage} from "../storage/LibAppStorage.sol";
 
@@ -423,8 +424,8 @@ contract EmbalmerFacet {
             LibTypes.ArchaeologistStorage memory archaeologistData = LibUtils
                 .getArchaeologist(identifier, archaeologistAddresses[i]);
 
-            // Transfer the archaeologist's digging fee allocation to the archaeologist
-            s.sarcoToken.transfer(
+            // Transfer the archaeologist's digging fee allocation to the archaeologist's reward pool
+            LibRewards.increaseRewardPool(
                 archaeologistAddresses[i],
                 archaeologistData.diggingFee
             );
@@ -438,7 +439,8 @@ contract EmbalmerFacet {
         // Add the protocol fee to the total protocol fees in storage
         s.totalProtocolFees += protocolFee;
 
-        // Transfer the new digging fees from the embalmer to the sarcophagus contract
+        // Transfer the new digging fees from the embalmer to the sarcophagus contract.
+        // Archaeologists may withdraw their due from their respective reward pools
         s.sarcoToken.transferFrom(
             msg.sender,
             address(this),
@@ -566,8 +568,8 @@ contract EmbalmerFacet {
             LibTypes.ArchaeologistStorage memory archaeologistData = LibUtils
                 .getArchaeologist(identifier, archaeologistAddresses[i]);
 
-            // Transfer the digging fees to the archaeologist
-            s.sarcoToken.transfer(
+            // Transfer the digging fees to the archaeologist's reward pool
+            LibRewards.increaseRewardPool(
                 archaeologistAddresses[i],
                 archaeologistData.diggingFee
             );

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -183,9 +183,16 @@ contract ThirdPartyFacet {
                 }
             }
 
-            // If this arch address wasn't in the accused list, reimburse it
+            // If this arch address wasn't in the accused list, free it from its curse
             if (isUnaccused) {
-                _reimburseArch(sarcoId, sarcoArchsAddresses[i]);
+                // There are technically no rewards here, since the sarcophagus
+                // has been compromised, so here this effectively merely resets
+                // the state of the non-malicious archaeologists, as if they never
+                // bonded to this sarcophagus in the first place.
+                //
+                // Of course, whatever rewards they might have gained in previous
+                // rewraps remains theirs.
+                LibBonds.freeArchaeologist(sarcoId, sarcoArchsAddresses[i]);
             }
         }
 
@@ -208,45 +215,6 @@ contract ThirdPartyFacet {
             accuserBondReward,
             embalmerBondReward
         );
-    }
-
-    /**
-     * @notice Transfers the value of the cursed bond of the archaeologist back to them, and un-curses their bond.
-     * @param sarcoId The identifier of the sarcophagus for which the bonds were cursed
-     * @param arch Address of the archaeologist to reimburse
-     */
-    function _reimburseArch(bytes32 sarcoId, address arch) private {
-        LibTypes.ArchaeologistStorage storage goodArch = s
-            .sarcophagusArchaeologists[sarcoId][arch];
-
-        uint256 cursedBond = LibBonds.calculateCursedBond(
-            goodArch.diggingFee,
-            goodArch.bounty
-        );
-
-        s.sarcoToken.transfer(arch, cursedBond);
-        LibBonds.freeArchaeologist(sarcoId, arch);
-    }
-
-    /**
-     * @notice After a sarcophagus has been successfully accused, transfers the value
-     * of the cursed bonds of the archs back to them, and un-curses their bonds.
-     * @dev not using this in accuse because it'd involve yet another loop.
-     * Instead, _reimburseArch will run on each unaccused archaeologist that's found.
-     * @param sarcoId The identifier of the sarcophagus for which the bonds were cursed
-     * @param archs The archaeologists to reimburse
-     * @param amounts amounts of sarco tokens to transfer to archaeologists. Should be in same order
-     * as archs.
-     */
-    function _reimburseArchs(
-        bytes32 sarcoId,
-        address[] storage archs,
-        uint256[] memory amounts
-    ) private {
-        for (uint256 i = 0; i < archs.length; i++) {
-            s.sarcoToken.transfer(archs[i], amounts[i]);
-            LibBonds.freeArchaeologist(sarcoId, archs[i]);
-        }
     }
 
     /**

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -31,6 +31,18 @@ contract ViewStateFacet {
         return s.freeBonds[archaeologist];
     }
 
+    /// @notice Returns the amount of rewards stored in the contract for an
+    /// archaeologist.
+    /// @param archaeologist The address of the archaeologist whose
+    /// reward is being returned
+    function getAvailableRewards(address archaeologist)
+        external
+        view
+        returns (uint256)
+    {
+        return s.archaeologistRewards[archaeologist];
+    }
+
     /// @notice Returns the amount of cursed bond stored in the contract for an
     /// archaeologist.
     /// @param archaeologist The address of the archaeologist whose

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -31,6 +31,8 @@ library LibErrors {
 
     error NotEnoughFreeBond(uint256 freeBond, uint256 amount);
 
+    error NotEnoughReward(uint256 reward, uint256 amount);
+
     error ResurrectionTimeInPast(uint256 resurrectionTime);
 
     error SarcophagusAlreadyExists(bytes32 identifier);

--- a/contracts/libraries/LibEvents.sol
+++ b/contracts/libraries/LibEvents.sol
@@ -42,6 +42,11 @@ library LibEvents {
         uint256 withdrawnBond
     );
 
+    event WithdrawReward(
+        address indexed archaeologist,
+        uint256 withdrawnReward
+    );
+
     event DepositFreeBond(address indexed archaeologist, uint256 depositedBond);
 
     event InitializeSarcophagus(

--- a/contracts/libraries/LibRewards.sol
+++ b/contracts/libraries/LibRewards.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+import "../storage/LibAppStorage.sol";
+import "../libraries/LibTypes.sol";
+import {LibErrors} from "../libraries/LibErrors.sol";
+
+library LibRewards {
+    /// @notice Decreases the amount stored in the archaeologistRewards mapping for an
+    /// archaeologist. Reverts if the archaeologist's reward is lower than
+    /// the amount. Called on reward withdraw.
+    /// @param archaeologist The address of the archaeologist whose
+    /// reward is being decreased
+    /// @param amount The amount to decrease the reward by
+    function decreaseRewardPool(address archaeologist, uint256 amount)
+        internal
+    {
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        // Revert if the amount is greater than the current reward
+        if (amount > s.archaeologistRewards[archaeologist]) {
+            revert LibErrors.NotEnoughReward(
+                s.archaeologistRewards[archaeologist],
+                amount
+            );
+        }
+
+        // Decrease the free bond amount
+        s.archaeologistRewards[archaeologist] -= amount;
+    }
+
+    /// @notice Increases the amount stored in the archaeologistRewards mapping for an
+    /// archaeologist.
+    /// @param amount The amount to increase the reward by
+    /// @param archaeologist The address of the archaeologist whose
+    /// reward is being increased
+    function increaseRewardPool(address archaeologist, uint256 amount)
+        internal
+    {
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        s.archaeologistRewards[archaeologist] += amount;
+    }
+}

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -20,6 +20,9 @@ struct AppStorage {
     mapping(address => bytes32[]) archaeologistCancels;
     mapping(address => bytes32[]) archaeologistAccusals;
     mapping(address => bytes32[]) archaeologistCleanups;
+    // Track how much archaeologists have made. To be credited and debited
+    // as archaeologists fulfil their duties and withdraw their rewards
+    mapping(address => uint256) archaeologistRewards;
     // sarcophaguses
     bytes32[] sarcophagusIdentifiers;
     mapping(bytes32 => LibTypes.Sarcophagus) sarcophaguses;

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -622,9 +622,10 @@ describe("Contract: EmbalmerFacet", () => {
           archaeologists[1].address
         );
 
-        // TODO: Modify this when the calculateCursedBond method changes in the contract
-        const firstArchaeologistCursedBond =
-          archaeologistsFees[1].bounty + archaeologistsFees[1].diggingFee;
+        const firstArchaeologistCursedBond = calculateCursedBond(
+          BigNumber.from(archaeologistsFees[1].diggingFee),
+          BigNumber.from(archaeologistsFees[1].bounty)
+        );
 
         expect(freeBondBefore.sub(freeBondAfter)).to.equal(
           BigNumber.from(firstArchaeologistCursedBond)

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -11,7 +11,12 @@ import {
 } from "../../typechain";
 import { EmbalmerFacet } from "../../typechain/EmbalmerFacet";
 import { SarcophagusState, SignatureWithAccount } from "../../types";
-import { calculateCursedBond, sign } from "../utils/helpers";
+import {
+  calculateCursedBond,
+  getArchaeologistSarcoBalances,
+  getArchaeologistSarcoRewards,
+  sign
+} from "../utils/helpers";
 
 describe("Contract: EmbalmerFacet", () => {
   // Define a resurrrection time one week in the future
@@ -193,28 +198,6 @@ describe("Contract: EmbalmerFacet", () => {
     );
 
     return { identifier: newIdentifier, signatures: newSignatures };
-  };
-
-  /**
-   * Gets a list of archaeologist sarco balances.
-   *
-   * @param archaeologists A list of archaeologist signers
-   * @returns a list of archaeologist sarco balanaces
-   */
-  const getArchaeologistSarcoBalances = async (
-    archaeologists: SignerWithAddress[],
-    sarcoToken: SarcoTokenMock
-  ): Promise<{ address: string; balance: BigNumber }[]> => {
-    const balances: { address: string; balance: BigNumber }[] = [];
-    for (const arch of archaeologists) {
-      const balance = await sarcoToken.balanceOf(arch.address);
-      balances.push({
-        address: arch.address,
-        balance: balance,
-      });
-    }
-
-    return balances;
   };
 
   describe("initializeSarcophagus()", () => {
@@ -576,15 +559,15 @@ describe("Contract: EmbalmerFacet", () => {
         expect(sarcophagusStored.arweaveTxIds).to.contain(arweaveTxId);
       });
 
-      it("should transfer the storage fee to the arweave archaeologist", async () => {
+      it("should transfer the storage fee to the arweave archaeologist's reward pool", async () => {
         const { identifier, signatures } = await createSarcophagusAndSignatures(
           "shouldTransferStorageFee",
           archaeologists
         );
 
         // Get the arweave archaeologist's sarco token balance before finalization
-        const arweaveArchaeologistSarcoTokenBalanceBefore =
-          await sarcoToken.balanceOf(arweaveArchaeologist.address);
+        const arweaveArchaeologistRewardsBefore =
+          await viewStateFacet.getAvailableRewards(arweaveArchaeologist.address);
 
         await embalmerFacet.finalizeSarcophagus(
           identifier,
@@ -602,16 +585,12 @@ describe("Contract: EmbalmerFacet", () => {
         );
 
         // Get the arweave archaeologist's sarco token balance after finalization
-        const arweaveArchSarcoBalanceAfter = await sarcoToken.balanceOf(
-          arweaveArchaeologist.address
-        );
+        const arweaveArchRewardsAfter = await viewStateFacet.getAvailableRewards(arweaveArchaeologist.address);
 
         // Check that the arweave archaeologist's
         // sarco token balance after - sarco token balance before = storage fee
         expect(
-          arweaveArchSarcoBalanceAfter.sub(
-            arweaveArchaeologistSarcoTokenBalanceBefore
-          )
+          arweaveArchRewardsAfter.sub(arweaveArchaeologistRewardsBefore)
         ).to.equal(arweaveArchaeologistStorageFee);
       });
 
@@ -1081,7 +1060,7 @@ describe("Contract: EmbalmerFacet", () => {
         );
       });
 
-      it("should transfer the digging fees to the archaeologists", async () => {
+      it("should transfer the digging fees to the archaeologists' reward pools, without transferring tokens", async () => {
         const { identifier, signatures } = await createSarcophagusAndSignatures(
           "shouldTransferDiggingFees",
           archaeologists
@@ -1099,6 +1078,11 @@ describe("Contract: EmbalmerFacet", () => {
           sarcoToken
         );
 
+        const archRewardsBefore = await getArchaeologistSarcoRewards(
+          archaeologists,
+          viewStateFacet
+        );
+
         // Define a new resurrection time one week in the future
         const newResurrectionTime = BigNumber.from(
           Date.now() + 60 * 60 * 24 * 7 * 1000
@@ -1112,14 +1096,24 @@ describe("Contract: EmbalmerFacet", () => {
           sarcoToken
         );
 
-        // For each archaeologist, check that the difference in balances is equal to each archaeologist's digging fee
+        const archRewardsAfter = await getArchaeologistSarcoRewards(
+          archaeologists,
+          viewStateFacet
+        );
+
+        // For each archaeologist, check that the difference in rewards is equal to each archaeologist's digging fee,
+        //  and token balances are unchanged
         for (let i = 0; i < archaeologists.length; i++) {
           const diggingFee = archaeologistsFees[i].diggingFee;
           expect(
-            archBalancesAfter[i].balance
-              .sub(archBalancesBefore[i].balance)
+            archRewardsBefore[i].reward
+              .add(diggingFee)
               .toString()
-          ).to.equal(diggingFee.toString());
+          ).to.equal(archRewardsAfter[i].reward.toString());
+
+          expect(
+            archBalancesAfter[i].balance.toString()
+          ).to.equal(archBalancesBefore[i].balance.toString());
         }
       });
 
@@ -1213,9 +1207,17 @@ describe("Contract: EmbalmerFacet", () => {
           totalProtocolFeesAfter.sub(totalProtocolFeesBefore).toString()
         ).to.equal(protocolFee.toString());
 
-        // Check that the difference in contract balance is equal to the protocol fee amount
+
+
+        // Calculate the sum of digging fees from archaeologistFees
+        const diggingFeeSum = archaeologistsFees.reduce(
+          (acc, cur) => acc.add(cur.diggingFee),
+          BigNumber.from(0)
+        );
+
+        // Check that the difference in contract balance is equal to the protocol fee amount + digging fee sum
         expect(
-          contractBalanceAfter.sub(contractBalanceBefore).toString()
+          contractBalanceAfter.sub(contractBalanceBefore.add(diggingFeeSum)).toString()
         ).to.equal(protocolFee.toString());
       });
 
@@ -1640,7 +1642,7 @@ describe("Contract: EmbalmerFacet", () => {
         );
       });
 
-      it("should transfer digging fees to each archaeologist", async () => {
+      it("should only transfer digging fees to each archaeologist's reward pool, without doing actual token transfers", async () => {
         // Initialize a sarcophagus
         const { identifier, signatures } = await createSarcophagusAndSignatures(
           "shouldTransferDigginFees",
@@ -1655,26 +1657,32 @@ describe("Contract: EmbalmerFacet", () => {
           arweaveTxId
         );
 
-        // Get the archaeologist's sarco balance before bury
-        const sarcoBalanceBefore = await sarcoToken.balanceOf(
-          archaeologists[0].address
-        );
+        // Get the archaeologist's sarco balances and rewards before bury
+        const archBalancesBefore = await getArchaeologistSarcoBalances(archaeologists, sarcoToken);
+        const archRewardsBefore = await getArchaeologistSarcoRewards(archaeologists, viewStateFacet);
 
         // Bury the sarcophagus
         await embalmerFacet.burySarcophagus(identifier);
 
-        // Get the archaeologist sarco balance after bury
-        const sarcoBalanceAfter = await sarcoToken.balanceOf(
-          archaeologists[0].address
-        );
+        // Get the archaeologist sarco balances and rewards after bury
+        const archBalancesAfter = await getArchaeologistSarcoBalances(archaeologists, sarcoToken);
+        const archRewardsAfter = await getArchaeologistSarcoRewards(archaeologists, viewStateFacet);
 
-        // Get the archaeologist's digging fees with the archaeologist address
-        const diggingFee = archaeologistsFees[0].diggingFee;
 
-        // Check that the difference in balances is equal to the digging fee
-        expect(sarcoBalanceAfter.sub(sarcoBalanceBefore).toString()).to.equal(
-          diggingFee.toString()
-        );
+        for (let i = 0; i < archaeologists.length; i++) {
+          // Get the archaeologist's digging fees with the archaeologist address
+          const diggingFee = archaeologistsFees[i].diggingFee;
+
+          // Check that the difference in rewards is equal to the digging fee
+          expect(archBalancesAfter[i].balance.toString()).to.equal(
+            archBalancesBefore[i].balance.toString()
+          );
+
+          expect(archRewardsAfter[i].reward.toString()).to.equal(
+            archRewardsBefore[i].reward.add(diggingFee).toString()
+          );
+        }
+
       });
 
       it("should transfer the bounty back to the embalmer", async () => {

--- a/test/facets/third-party-facet.spec.ts
+++ b/test/facets/third-party-facet.spec.ts
@@ -558,28 +558,20 @@ describe("Contract: ThirdPartyFacet", () => {
         expect(freeBond2Before.lt(freeBond2After)).to.be.true;
       });
 
-      it("Should distribute the bounties and digging fees of unaccused archaeologists back to them", async () => {
+      it("Should not actually transfer tokens (being explicit here, cz of recent refactoring)", async () => {
         const unaccusedArchaeologist1BalBefore = await sarcoToken.balanceOf(arweaveAchaeologist.address);
         const unaccusedArchaeologist2BalBefore = await sarcoToken.balanceOf(unaccusedArchaeologist.address);
 
         const tx = await thirdPartyFacet.connect(thirdParty).accuse(sarcoId, unencryptedShards.slice(0, 2), paymentAccount.address);
         await tx.wait();
 
-        // Set up amounts that should have been transferred to unaccused archaeologists
-        const arch1 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, arweaveAchaeologist.address);
-        const arch2 = await viewStateFacet.getSarcophagusArchaeologist(sarcoId, unaccusedArchaeologist.address);
-
-        const cursedBond1 = calculateCursedBond(arch1.diggingFee, arch1.bounty);
-        const cursedBond2 = calculateCursedBond(arch2.diggingFee, arch2.bounty);
-
         const unaccusedArchaeologist1BalAfter = await sarcoToken.balanceOf(arweaveAchaeologist.address);
         const unaccusedArchaeologist2BalAfter = await sarcoToken.balanceOf(unaccusedArchaeologist.address);
 
-        // Check that unaccused archaeologists now have balances that includes the amount that should have been transferred to them
-        expect(unaccusedArchaeologist1BalAfter.eq(unaccusedArchaeologist1BalBefore.add(cursedBond1))).to.be.true;
-        expect(unaccusedArchaeologist2BalAfter.eq(unaccusedArchaeologist2BalBefore.add(cursedBond2))).to.be.true;
-      }
-      );
+        // Check that unaccused archaeologists balances are unaffected
+        expect(unaccusedArchaeologist1BalAfter.eq(unaccusedArchaeologist1BalBefore)).to.be.true;
+        expect(unaccusedArchaeologist2BalAfter.eq(unaccusedArchaeologist2BalBefore)).to.be.true;
+      });
 
       it("Should add all accused archaeologists to archaeologistAccusals storage on successful accusal", async () => {
         const tx = await thirdPartyFacet.connect(thirdParty).accuse(sarcoId, unencryptedShards.slice(0, 2), paymentAccount.address);

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber, Signature } from "ethers";
 import { ethers } from "hardhat";
-import { ArchaeologistFacet, SarcoTokenMock } from "../../typechain";
+import { ArchaeologistFacet, SarcoTokenMock, ViewStateFacet } from "../../typechain";
 
 /**
  * Signs a message as any EVM compatible type and returns the signature and the
@@ -75,6 +75,54 @@ export const setupArchaeologists = async (
       .connect(archaeologist)
       .depositFreeBond(BigNumber.from("5000"));
   }
+};
+
+
+
+/**
+ * Gets a list of archaeologist sarco balances.
+ *
+ * @param archaeologists A list of archaeologist signers
+ * @returns a list of archaeologist sarco balanaces
+ */
+export const getArchaeologistSarcoBalances = async (
+  archaeologists: SignerWithAddress[],
+  sarcoToken: SarcoTokenMock
+): Promise<{ address: string; balance: BigNumber }[]> => {
+  const balances: { address: string; balance: BigNumber }[] = [];
+  for (const arch of archaeologists) {
+    const balance = await sarcoToken.balanceOf(arch.address);
+    balances.push({
+      address: arch.address,
+      balance: balance,
+    });
+  }
+
+  return balances;
+};
+
+
+
+/**
+ * Gets a list of archaeologist sarco rewards.
+ *
+ * @param archaeologists A list of archaeologist signers
+ * @returns a list of archaeologist sarco rewards
+ */
+export const getArchaeologistSarcoRewards = async (
+  archaeologists: SignerWithAddress[],
+  viewStateFacet: ViewStateFacet,
+): Promise<{ address: string; reward: BigNumber }[]> => {
+  const rewards: { address: string; reward: BigNumber }[] = [];
+  for (const arch of archaeologists) {
+    const reward = await viewStateFacet.getAvailableRewards(arch.address)
+    rewards.push({
+      address: arch.address,
+      reward: reward,
+    });
+  }
+
+  return rewards;
 };
 
 // TODO: update if calculate cursed bond algorithm changes (or possibly read this from contract instead?)


### PR DESCRIPTION
This PR removes all actual transfer of SARCO tokens to archaeologists, and replaces them with credits to a rewards pool mapping instead. Archaeologists can manually withdraw from their respective pools whenever they want.