### PR TITLE
Implements max rewrap interval

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -95,10 +95,7 @@ contract ArchaeologistFacet {
 
         // Confirm that the resurrection time has passed and that the
         // resurrection window has not passed
-        LibUtils.unwrapTime(
-            s.sarcophagi[sarcoId].resurrectionTime,
-            s.sarcophagi[sarcoId].resurrectionWindow
-        );
+        LibUtils.unwrapTime(s.sarcophagi[sarcoId].resurrectionTime);
 
         // Comfirm that the sarcophagus has been finalized
         if (!LibUtils.isSarcophagusFinalized(sarcoId)) {

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -73,7 +73,7 @@ contract EmbalmerFacet {
         bool canBeTransferred,
         uint8 minShards
     ) external returns (uint256) {
-        bytes32 sarcoId = keccak256(abi.encode(name));
+        bytes32 sarcoId = keccak256(abi.encodePacked(name));
 
         // Confirm that this exact sarcophagus does not already exist
         if (

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -408,6 +408,17 @@ contract EmbalmerFacet {
             revert LibErrors.NewResurrectionTimeInPast(resurrectionTime);
         }
 
+        // Confirm that the new resurrection time is not more than
+        // `maxResurrectionInterval` seconds into the future
+        if (
+            resurrectionTime - block.timestamp >
+            s.sarcophagi[sarcoId].maxResurrectionInterval
+        ) {
+            revert LibErrors.NewResurrectionTimeTooLarge(
+                s.sarcophagi[sarcoId].resurrectionTime
+            );
+        }
+
         // Calculate the new resurrectionWindow, which is the amount of time in
         // seconds that an archaeologist has to unwrap after the resurrection
         // time has passed.

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -396,11 +396,9 @@ contract EmbalmerFacet {
             revert LibErrors.SarcophagusNotFinalized(sarcoId);
         }
 
-        // Confirm that the current resurrection time is in the future
+        // Confirm that the current resurrection time is in the future, and thus rewrappable
         if (s.sarcophagi[sarcoId].resurrectionTime <= block.timestamp) {
-            revert LibErrors.NewResurrectionTimeInPast(
-                s.sarcophagi[sarcoId].resurrectionTime
-            );
+            revert LibErrors.SarcophagusIsUnwrappable();
         }
 
         // Confirm that the new resurrection time is in the future

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -439,6 +439,9 @@ contract EmbalmerFacet {
         // Add the protocol fee to the total protocol fees in storage
         s.totalProtocolFees += protocolFee;
 
+        // Set resurrection time to infinity
+        s.sarcophagi[sarcoId].resurrectionTime = resurrectionTime;
+
         // Transfer the new digging fees from the embalmer to the sarcophagus contract.
         // Archaeologists may withdraw their due from their respective reward pools
         s.sarcoToken.transferFrom(

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -103,6 +103,11 @@ contract EmbalmerFacet {
             revert LibErrors.MinShardsZero();
         }
 
+        // Confirm that maxResurrectionInterval is greater than 0
+        if (maxResurrectionInterval == 0) {
+            revert LibErrors.MaxResurrectionIntervalIsZero();
+        }
+
         // Initialize a list of archaeologist addresses to be passed in to the
         // sarcophagus object
         address[] memory archaeologistsToBond = new address[](

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -21,11 +21,7 @@ contract EmbalmerFacet {
 
     event FinalizeSarcophagus(bytes32 indexed sarcoId, string arweaveTxId);
 
-    event RewrapSarcophagus(
-        bytes32 indexed sarcoId,
-        uint256 resurrectionTime,
-        uint256 resurrectionWindow
-    );
+    event RewrapSarcophagus(bytes32 indexed sarcoId, uint256 resurrectionTime);
 
     event CancelSarcophagus(bytes32 indexed sarcoId);
 
@@ -181,7 +177,6 @@ contract EmbalmerFacet {
             canBeTransferred: canBeTransferred,
             minShards: minShards,
             resurrectionTime: resurrectionTime,
-            resurrectionWindow: LibUtils.getGracePeriod(resurrectionTime),
             maxResurrectionInterval: maxResurrectionInterval,
             arweaveTxIds: new string[](0),
             storageFee: storageFee,
@@ -417,15 +412,6 @@ contract EmbalmerFacet {
             );
         }
 
-        // Calculate the new resurrectionWindow, which is the amount of time in
-        // seconds that an archaeologist has to unwrap after the resurrection
-        // time has passed.
-        uint256 resurrectionWindow = LibUtils.getGracePeriod(resurrectionTime);
-
-        // Store the new resurrectionTime and resurrectionWindow
-        s.sarcophagi[sarcoId].resurrectionTime = resurrectionTime;
-        s.sarcophagi[sarcoId].resurrectionWindow = resurrectionWindow;
-
         // For each archaeologist on the sarcophagus, transfer their digging fee allocations to them
         address[] memory bondedArchaeologists = s
             .sarcophagi[sarcoId]
@@ -462,7 +448,7 @@ contract EmbalmerFacet {
         );
 
         // Emit an event
-        emit RewrapSarcophagus(sarcoId, resurrectionTime, resurrectionWindow);
+        emit RewrapSarcophagus(sarcoId, resurrectionTime);
     }
 
     /// @notice Cancels a sarcophagus. An embalmer may cancel a sarcophagus after

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -15,13 +15,7 @@ contract EmbalmerFacet {
 
     event InitializeSarcophagus(
         bytes32 indexed sarcoId,
-        string name,
-        bool canBeTransferred,
-        uint256 resurrectionTime,
         address embalmer,
-        address recipientAddress,
-        address arweaveArchaeologist,
-        address[] archaeologists,
         uint256 totalFees
     );
 
@@ -60,24 +54,27 @@ contract EmbalmerFacet {
     /// finalizeSarcohpagus() method should be called, which is the second step.
     ///
     /// @param name the name of the sarcophagus
-    /// @param sarcoId the identifier of the sarcophagus
     /// @param archaeologists the data for the archaeologists
     /// @param arweaveArchaeologist The address of the archaeologist who uploads to arweave
     /// @param recipient the address of the recipient
     /// @param resurrectionTime the resurrection time of the sarcophagus
+    /// @param maxResurrectionInterval the maximum length of time that any new resurrection times can be from time of rewrap
+    /// @dev archaeologists will have to sign off on this interval, and commit to it for the lifetime of the sarcophagus.
     /// @param canBeTransferred Whether the sarcophagus can be transferred
     /// @param minShards The minimum number of shards required to unwrap the sarcophagus
     /// @return The index of the new sarcophagus
     function initializeSarcophagus(
         string memory name,
-        bytes32 sarcoId,
         LibTypes.ArchaeologistMemory[] memory archaeologists,
         address arweaveArchaeologist,
         address recipient,
         uint256 resurrectionTime,
+        uint256 maxResurrectionInterval,
         bool canBeTransferred,
         uint8 minShards
     ) external returns (uint256) {
+        bytes32 sarcoId = keccak256(abi.encode(name));
+
         // Confirm that this exact sarcophagus does not already exist
         if (
             s.sarcophagi[sarcoId].state !=
@@ -118,15 +115,12 @@ contract EmbalmerFacet {
         uint256 storageFee = 0;
 
         for (uint256 i = 0; i < archaeologists.length; i++) {
+            LibTypes.ArchaeologistMemory memory arch = archaeologists[i];
+
             // Confirm that the archaeologist list is unique. This is done by
             // checking that the archaeologist does not already exist from
             // previous iterations in this loop.
-            if (
-                LibUtils.archaeologistExistsOnSarc(
-                    sarcoId,
-                    archaeologists[i].archAddress
-                )
-            ) {
+            if (LibUtils.archaeologistExistsOnSarc(sarcoId, arch.archAddress)) {
                 revert LibErrors.ArchaeologistListNotUnique(
                     archaeologistsToBond
                 );
@@ -134,41 +128,36 @@ contract EmbalmerFacet {
 
             // If the archaeologist is the arweave archaeologist, set the
             // storage fee. This is the only storage fee we care about.
-            if (archaeologists[i].archAddress == arweaveArchaeologist) {
-                storageFee = archaeologists[i].storageFee;
+            if (arch.archAddress == arweaveArchaeologist) {
+                storageFee = arch.storageFee;
             }
 
             // Define an archaeologist storage object to be stored on the sarcophagus.
-            bytes32 doubleHashedShard = keccak256(
-                abi.encode(archaeologists[i].hashedShard)
-            );
+            bytes32 doubleHashedShard = keccak256(abi.encode(arch.hashedShard));
             LibTypes.ArchaeologistStorage memory archaeologistStorage = LibTypes
                 .ArchaeologistStorage({
-                    diggingFee: archaeologists[i].diggingFee,
-                    bounty: archaeologists[i].bounty,
+                    diggingFee: arch.diggingFee,
+                    bounty: arch.bounty,
                     doubleHashedShard: doubleHashedShard,
                     unencryptedShard: ""
                 });
 
-            // Map the hashed shared to this archaeologist's address for easier referencing on accuse
-            s.doubleHashedShardArchaeologists[
-                doubleHashedShard
-            ] = archaeologists[i].archAddress;
+            // Map the double-hashed shared to this archaeologist's address for easier referencing on accuse
+            s.doubleHashedShardArchaeologists[doubleHashedShard] = arch
+                .archAddress;
 
             // Stores each archaeologist's bounty, digging fees, and unencrypted
             // shard in app storage per sarcophagus
             s.sarcophagusArchaeologists[sarcoId][
-                archaeologists[i].archAddress
+                arch.archAddress
             ] = archaeologistStorage;
 
             // Add the sarcophagus identifier to archaeologist's list of sarcophagi
-            s.archaeologistSarcophagi[archaeologists[i].archAddress].push(
-                sarcoId
-            );
+            s.archaeologistSarcophagi[arch.archAddress].push(sarcoId);
 
             // Add the archaeologist address to the list of addresses to be
             // passed in to the sarcophagus object
-            archaeologistsToBond[i] = archaeologists[i].archAddress;
+            archaeologistsToBond[i] = arch.archAddress;
         }
 
         // If the storage fee is 0, then the storage fee was never set since the
@@ -188,6 +177,7 @@ contract EmbalmerFacet {
             minShards: minShards,
             resurrectionTime: resurrectionTime,
             resurrectionWindow: LibUtils.getGracePeriod(resurrectionTime),
+            maxResurrectionInterval: maxResurrectionInterval,
             arweaveTxIds: new string[](0),
             storageFee: storageFee,
             embalmer: msg.sender,
@@ -212,17 +202,7 @@ contract EmbalmerFacet {
         s.sarcoToken.transferFrom(msg.sender, address(this), totalFees);
 
         // Emit the event
-        emit InitializeSarcophagus(
-            sarcoId,
-            name,
-            canBeTransferred,
-            resurrectionTime,
-            msg.sender,
-            recipient,
-            arweaveArchaeologist,
-            archaeologistsToBond,
-            totalFees
-        );
+        emit InitializeSarcophagus(sarcoId, msg.sender, totalFees);
 
         // Return the index of the sarcophagus
         return s.sarcophagusIdentifiers.length - 1;

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -58,6 +58,7 @@ contract EmbalmerFacet {
     /// @dev archaeologists will have to sign off on this interval, and commit to it for the lifetime of the sarcophagus.
     /// @param canBeTransferred Whether the sarcophagus can be transferred
     /// @param minShards The minimum number of shards required to unwrap the sarcophagus
+    /// @param sarcoId Unique identifier of the sarcophagus
     /// @return The index of the new sarcophagus
     function initializeSarcophagus(
         string memory name,
@@ -67,10 +68,9 @@ contract EmbalmerFacet {
         uint256 resurrectionTime,
         uint256 maxResurrectionInterval,
         bool canBeTransferred,
-        uint8 minShards
+        uint8 minShards,
+        bytes32 sarcoId
     ) external returns (uint256) {
-        bytes32 sarcoId = keccak256(abi.encodePacked(name));
-
         // Confirm that this exact sarcophagus does not already exist
         if (
             s.sarcophagi[sarcoId].state !=

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -27,6 +27,8 @@ library LibErrors {
 
     error NewResurrectionTimeInPast(uint256 newResurrectionTime);
 
+    error NewResurrectionTimeTooLarge(uint256 newResurrectionTime);
+
     error NoArchaeologistsProvided();
 
     error NotEnoughCursedBond(uint256 cursedBond, uint256 amount);
@@ -56,7 +58,7 @@ library LibErrors {
 
     error SignerNotArchaeologistOnSarcophagus(bytes32 sarcoId, address signer);
 
-    // Used when an attempt is made to send an accusation after the resurrection time has already passed (so it's actually time to unwrap it)
+    // Used when an attempt is made to accuse or rewrap after the resurrection time has already passed (so it's actually time to unwrap it)
     error SarcophagusIsUnwrappable();
 
     // Used when an attempt is made to clean a sarcophagus that has not exceeded its resurrection window

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -23,6 +23,8 @@ library LibErrors {
 
     error MinShardsZero();
 
+    error MaxResurrectionIntervalIsZero();
+
     error NewResurrectionTimeInPast(uint256 newResurrectionTime);
 
     error NoArchaeologistsProvided();

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -78,6 +78,7 @@ library LibTypes {
         uint8 minShards;
         uint256 resurrectionTime;
         uint256 resurrectionWindow;
+        uint256 maxResurrectionInterval;
         string[] arweaveTxIds;
         uint256 storageFee;
         address embalmer;

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -77,7 +77,6 @@ library LibTypes {
         bool canBeTransferred;
         uint8 minShards;
         uint256 resurrectionTime;
-        uint256 resurrectionWindow;
         uint256 maxResurrectionInterval;
         string[] arweaveTxIds;
         uint256 storageFee;

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -225,13 +225,8 @@ library LibUtils {
      * side)
      * @param resurrectionTime the resurrection time of the sarcophagus
      * (absolute, i.e. a date time stamp)
-     * @param resurrectionWindow the resurrection window of the sarcophagus
-     * (relative, i.e. "30 minutes")
      */
-    function unwrapTime(uint256 resurrectionTime, uint256 resurrectionWindow)
-        internal
-        view
-    {
+    function unwrapTime(uint256 resurrectionTime) internal view {
         // revert if too early
         if (resurrectionTime > block.timestamp) {
             revert LibErrors.TooEarlyToUnwrap(
@@ -239,6 +234,8 @@ library LibUtils {
                 block.timestamp
             );
         }
+
+        uint256 resurrectionWindow = getGracePeriod(resurrectionTime);
 
         // revert if too late
         if (resurrectionTime + resurrectionWindow < block.timestamp) {
@@ -264,7 +261,8 @@ library LibUtils {
         // If the doubleHashedShard on an archaeologist is 0 (which is its default value),
         // then the archaeologist doesn't exist on the sarcophagus
         return
-            s.sarcophagusArchaeologists[sarcoId][archaeologist]
+            s
+            .sarcophagusArchaeologists[sarcoId][archaeologist]
                 .doubleHashedShard != 0;
     }
 

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -92,7 +92,8 @@ describe("Contract: EmbalmerFacet", () => {
             resurrectionTime,
             time.duration.weeks(1),
             true,
-            threshold
+            threshold,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("SarcophagusAlreadyExists");
@@ -120,7 +121,8 @@ describe("Contract: EmbalmerFacet", () => {
             resurrectionTime,
             time.duration.weeks(1),
             true,
-            threshold
+            threshold,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("ResurrectionTimeInPast");
@@ -151,7 +153,8 @@ describe("Contract: EmbalmerFacet", () => {
             (await time.latest()) + 100,
             time.duration.weeks(1),
             true,
-            threshold
+            threshold,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("NoArchaeologistsProvided");
@@ -183,7 +186,8 @@ describe("Contract: EmbalmerFacet", () => {
             (await time.latest()) + 100,
             time.duration.weeks(1),
             true,
-            threshold
+            threshold,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("ArchaeologistListNotUnique");
@@ -210,7 +214,8 @@ describe("Contract: EmbalmerFacet", () => {
             (await time.latest()) + 100,
             time.duration.weeks(1),
             true,
-            archaeologists.length + 1
+            archaeologists.length + 1,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("MinShardsGreaterThanArchaeologists");
@@ -237,7 +242,8 @@ describe("Contract: EmbalmerFacet", () => {
             (await time.latest()) + 100,
             time.duration.weeks(1),
             true,
-            0
+            0,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("MinShardsZero");
@@ -260,7 +266,8 @@ describe("Contract: EmbalmerFacet", () => {
             (await time.latest()) + 100,
             time.duration.weeks(1),
             true,
-            threshold
+            threshold,
+            sarcoId
           );
 
         await expect(tx).to.be.revertedWith("ArweaveArchaeologistNotInList");

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -580,7 +580,7 @@ describe("Contract: EmbalmerFacet", () => {
         expect(sarcophagusStored.resurrectionTime).to.equal(newResurrectionTime.toString());
       });
 
-      it("should store the new resurrection window", async () => {
+      it.skip("should store the new resurrection window", async () => {
         const { viewStateFacet, sarcoId, oldResurrectionWindow } = await rewrapFixture(
           { shares, threshold },
           sarcoName
@@ -695,6 +695,18 @@ describe("Contract: EmbalmerFacet", () => {
         const tx = embalmerFacet.connect(embalmer).rewrapSarcophagus(sarcoId, newResurrectionTime);
 
         await expect(tx).to.be.revertedWith("NewResurrectionTimeInPast");
+      });
+
+      it("should revert if the new resurrection time is further in the future than maxResurrectionTime allows", async () => {
+        const { tx } = await rewrapFixture(
+          { shares, threshold, dontAwaitTransaction: true },
+          sarcoName,
+          // Add 60 seconds to known default maxResurrectionInterval (from rewrapFixture's createSarcoFixture)
+          // of 1 week
+          time.duration.weeks(1) + 60
+        );
+
+        await expect(tx).to.be.revertedWith("NewResurrectionTimeTooLarge");
       });
     });
   });

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -126,6 +126,16 @@ describe("Contract: EmbalmerFacet", () => {
         await expect(tx).to.be.revertedWith("ResurrectionTimeInPast");
       });
 
+      it("should revert if maxResurrectionInterval is 0", async () => {
+        const { initializeTx } = await createSarcoFixture(
+          { shares, threshold, skipFinalize: true, dontAwaitInitTx: true },
+          sarcoName,
+          0
+        );
+
+        await expect(initializeTx).to.be.revertedWith("MaxResurrectionIntervalIsZero");
+      });
+
       it("should revert if no archaeologists are provided", async () => {
         const { sarcoId, embalmerFacet, embalmer, arweaveArchaeologist, recipient } =
           await createSarcoFixture({ shares, threshold, skipInitialize: true }, sarcoName);

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -52,6 +52,16 @@ describe("Contract: EmbalmerFacet", () => {
 
         expect(initializeTx).to.emit(embalmerFacet, "InitializeSarcophagus");
       });
+
+      it("should set a maximum resurrection interval", async () => {
+        const { sarcoId, viewStateFacet } = await createSarcoFixture(
+          { shares, threshold, skipFinalize: true },
+          sarcoName
+        );
+
+        const sarco = await viewStateFacet.getSarcophagus(sarcoId);
+        expect(sarco.maxResurrectionInterval).to.not.be.undefined;
+      });
     });
 
     context("Failed initialization", () => {
@@ -76,11 +86,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             archaeologists,
             arweaveArchaeologist.signer.address,
             recipient.address,
             resurrectionTime,
+            time.duration.weeks(1),
             true,
             threshold
           );
@@ -104,11 +114,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             archaeologists,
             arweaveArchaeologist.archAddress,
             recipient.address,
             resurrectionTime,
+            time.duration.weeks(1),
             true,
             threshold
           );
@@ -125,11 +135,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             [],
             arweaveArchaeologist.archAddress,
             recipient.address,
             (await time.latest()) + 100,
+            time.duration.weeks(1),
             true,
             threshold
           );
@@ -157,11 +167,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             nonUniqueArchaeologists,
             arweaveArchaeologist.archAddress,
             recipient.address,
             (await time.latest()) + 100,
+            time.duration.weeks(1),
             true,
             threshold
           );
@@ -184,11 +194,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             archaeologists,
             arweaveArchaeologist.archAddress,
             recipient.address,
             (await time.latest()) + 100,
+            time.duration.weeks(1),
             true,
             archaeologists.length + 1
           );
@@ -211,11 +221,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             archaeologists,
             arweaveArchaeologist.archAddress,
             recipient.address,
             (await time.latest()) + 100,
+            time.duration.weeks(1),
             true,
             0
           );
@@ -234,11 +244,11 @@ describe("Contract: EmbalmerFacet", () => {
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             archaeologists,
             signers[9].address,
             recipient.address,
             (await time.latest()) + 100,
+            time.duration.weeks(1),
             true,
             threshold
           );

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -580,17 +580,6 @@ describe("Contract: EmbalmerFacet", () => {
         expect(sarcophagusStored.resurrectionTime).to.equal(newResurrectionTime.toString());
       });
 
-      it.skip("should store the new resurrection window", async () => {
-        const { viewStateFacet, sarcoId, oldResurrectionWindow } = await rewrapFixture(
-          { shares, threshold },
-          sarcoName
-        );
-
-        const sarcophagusStoredAfter = await viewStateFacet.getSarcophagus(sarcoId);
-
-        expect(sarcophagusStoredAfter.resurrectionWindow).to.not.equal(oldResurrectionWindow);
-      });
-
       it("should transfer the digging fee sum plus the protocol fee from the embalmer to the contract", async () => {
         const { archaeologists, sarcoToken, embalmer, embalmerBalanceBefore } = await rewrapFixture(
           { shares, threshold },

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -60,7 +60,7 @@ describe("Contract: EmbalmerFacet", () => {
         );
 
         const sarco = await viewStateFacet.getSarcophagus(sarcoId);
-        expect(sarco.maxResurrectionInterval).to.not.be.undefined;
+        expect(sarco.maxResurrectionInterval.toString()).to.eq(time.duration.weeks(1).toString());
       });
     });
 

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -142,7 +142,8 @@ export const createSarcoFixture = (
             resurrectionTime,
             maxResurrectionInterval ?? time.duration.weeks(1),
             canBeTransferred,
-            config.threshold
+            config.threshold,
+            sarcoId
           );
       }
 

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -140,7 +140,7 @@ export const createSarcoFixture = (
             arweaveArchaeologist.signer.address,
             recipient.address,
             resurrectionTime,
-            maxResurrectionInterval || time.duration.weeks(1),
+            maxResurrectionInterval ?? time.duration.weeks(1),
             canBeTransferred,
             config.threshold
           );

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -17,13 +17,16 @@ const sss = require("shamirs-secret-sharing");
  * A fixture to set up a test that reqiures a successful initialization on a
  * transferrable sarcophagus. Deploys all contracts required for the system,
  * and initializes a sarcophagus with given config and name, with archaeologists
- * created and pre-configured for it. Ressurection time is set to 1 week.
+ * created and pre-configured for it.
+ *
+ * Ressurection time is set to 1 week.
+ * maxResurrectionInterval defaults to 1 week.
+ * Arweave archaeologist is set to the first in the returned list of archaeologists.
+ *
  * Optionally, initialising and finalising may be skipped. It's also possible to
  * indicate to return a specified number of archaeologists not bonded to the
  * sarcophagus that is setup, and not await the initialise and/or finalise
  * transaction Promises.
- *
- * Arweave archaeologist is set to the first in the returned list of archaeologists.
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createSarcoFixture = (
@@ -36,7 +39,8 @@ export const createSarcoFixture = (
     dontAwaitFinalizeTx?: boolean;
     addUnbondedArchs?: number;
   },
-  sarcoName: string
+  sarcoName: string,
+  maxResurrectionInterval?: number
 ) =>
   deployments.createFixture(
     async ({ deployments, getNamedAccounts, getUnnamedAccounts, ethers }) => {
@@ -132,11 +136,11 @@ export const createSarcoFixture = (
           .connect(embalmer)
           .initializeSarcophagus(
             sarcoName,
-            sarcoId,
             archaeologists,
             arweaveArchaeologist.signer.address,
             recipient.address,
             resurrectionTime,
+            maxResurrectionInterval || time.duration.weeks(1),
             canBeTransferred,
             config.threshold
           );

--- a/test/fixtures/rewrap-fixture.ts
+++ b/test/fixtures/rewrap-fixture.ts
@@ -52,8 +52,6 @@ export const rewrapFixture = async (
   // Get the contract's sarco balance before rewrap
   const contractBalanceBefore = await sarcoToken.balanceOf(viewStateFacet.address);
 
-  const oldResurrectionWindow = (await viewStateFacet.getSarcophagus(sarcoId)).resurrectionWindow;
-
   // Calculate the sarco balances for each archaeologist before unwrap
   const archBalancesBefore = await Promise.all(
     archaeologists.map(async archaeologist => await sarcoToken.balanceOf(archaeologist.archAddress))
@@ -73,7 +71,6 @@ export const rewrapFixture = async (
     sarcoId,
     oldResurrectionTime,
     newResurrectionTime: _newResurrectionTime,
-    oldResurrectionWindow,
     archaeologists,
     sarcoToken,
     archBalancesBefore,


### PR DESCRIPTION
This value, a time interval in seconds, is set during sarcophagus initialisation and used to validate calls to rewrap -- setting a new resurrection time that causes the interval between it and the current time to be larger than the max interval causes a revert.

This branch is based on https://github.com/sarcophagus-org/sarcophagus-v2-contracts/pull/45, so that should be merged first, preferably even before review.