### PR TITLE
Register archaeologist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 typechain
 typechain-types
+.idea/
 
 #Hardhat files
 cache

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -49,12 +49,6 @@ contract ArchaeologistFacet {
         // verify that the archaeologist does not already exist
         LibUtils.revertIfArchProfileExists(msg.sender);
 
-        // transfer SARCO tokens from the archaeologist to this contract, to be
-        // used as their free bond. can be 0.
-        if (freeBond > 0) {
-            s.sarcoToken.transferFrom(msg.sender, address(this), freeBond);
-        }
-
         // create a new archaeologist
         LibTypes.ArchaeologistProfile memory newArch =
             LibTypes.ArchaeologistProfile({
@@ -65,6 +59,12 @@ contract ArchaeologistFacet {
                 cursedBond: 0,
                 rewards: 0
             });
+
+        // transfer SARCO tokens from the archaeologist to this contract, to be
+        // used as their free bond. can be 0.
+        if (freeBond > 0) {
+            s.sarcoToken.transferFrom(msg.sender, address(this), freeBond);
+        }
 
         // save the new archaeologist into relevant data structures
         s.archaeologistProfiles[msg.sender] = newArch;

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -228,7 +228,7 @@ contract ArchaeologistFacet {
         // Transfer the nft to the new archaeologist. This is the only method of tranfering an nft
         // in the sarcophagus app. The owner of the nft may not transfer it themselves.
         // The contract needs to keep track of who owns the nft so that it can make the transfer
-        // again if the new archaeologist chooses to tranfer it to another archaeologist later on.
+        // again if the new archaeologist chooses to transfer it to another archaeologist later on.
         newArchData.curseTokenId = oldArchData.curseTokenId;
         oldArchData.curseTokenId = 0;
         s.curses.safeTransferFrom(oldArchaeologist, msg.sender, newArchData.curseTokenId, 1, "");

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -43,10 +43,10 @@ contract EmbalmerFacet {
     /// InitializeSarcophagus is the first step of the two step mummification
     /// process.
     ///
-    /// The purpose of intializeSarcophagus is to:
+    /// The purpose of initializeSarcophagus is to:
     ///   - Lock up payment for the archaeologists (bounty, digging fees, and storage fee)
     ///   - Store hashes of the unencrypted shards on chain
-    ///   - Store the particapting archaeologists' addresses and individual
+    ///   - Store the participating archaeologists' addresses and individual
     ///     denominations of fees dedicated to each
     ///   - Create the sarcophagus object
     ///
@@ -54,7 +54,7 @@ contract EmbalmerFacet {
     /// have no knowledge of the sarcophagus yet. An archaeologist still needs
     /// to upload a payload to arweave and also communicate directly with the
     /// embalmer to indicate that they are ready to do work. After this the
-    /// finalizeSarcohpagus() method should be called, which is the second step.
+    /// finalizeSarcophagus() method should be called, which is the second step.
     ///
     /// @param sarcoId the identifier of the sarcophagus
     /// @param sarcophagus an object that contains the sarcophagus data
@@ -64,7 +64,7 @@ contract EmbalmerFacet {
     function initializeSarcophagus(
         bytes32 sarcoId,
         LibTypes.SarcophagusMemory memory sarcophagus,
-        LibTypes.ArchaeologistMemory[] memory archaeologists,
+        LibTypes.SelectedArchaeologistMemory[] memory sarcoArchaeologists,
         address arweaveArchaeologist
     ) external returns (uint256) {
         // Confirm that this exact sarcophagus does not already exist
@@ -83,12 +83,12 @@ contract EmbalmerFacet {
         }
 
         // Confirm that archaeologists are provided
-        if (archaeologists.length == 0) {
+        if (sarcoArchaeologists.length == 0) {
             revert LibErrors.NoArchaeologistsProvided();
         }
 
         // Confirm that minShards is less than the number of archaeologists
-        if (sarcophagus.minShards > archaeologists.length) {
+        if (sarcophagus.minShards > sarcoArchaeologists.length) {
             revert LibErrors.MinShardsGreaterThanArchaeologists(
                 sarcophagus.minShards
             );
@@ -102,7 +102,7 @@ contract EmbalmerFacet {
         // Initialize a list of archaeologist addresses to be passed in to the
         // sarcophagus object
         address[] memory archaeologistsToBond = new address[](
-            archaeologists.length
+            sarcoArchaeologists.length
         );
 
         // Initialize the storage fee of the archaeologist who uploades to
@@ -110,8 +110,8 @@ contract EmbalmerFacet {
         // sarcophagus object.
         uint256 storageFee = 0;
 
-        for (uint256 i = 0; i < archaeologists.length; i++) {
-            LibTypes.ArchaeologistMemory memory arch = archaeologists[i];
+        for (uint256 i = 0; i < sarcoArchaeologists.length; i++) {
+            LibTypes.SelectedArchaeologistMemory memory arch = sarcoArchaeologists[i];
 
             // Confirm that the archaeologist list is unique. This is done by
             // checking that the archaeologist does not already exist from

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -58,7 +58,7 @@ contract EmbalmerFacet {
     ///
     /// @param sarcoId the identifier of the sarcophagus
     /// @param sarcophagus an object that contains the sarcophagus data
-    /// @param archaeologists the data for the archaeologists
+    /// @param selectedArchaeologists the data for the archaeologists
     /// @param arweaveArchaeologist The address of the archaeologist who uploads to arweave
     /// @return The index of the new sarcophagus
     function initializeSarcophagus(

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -64,7 +64,7 @@ contract EmbalmerFacet {
     function initializeSarcophagus(
         bytes32 sarcoId,
         LibTypes.SarcophagusMemory memory sarcophagus,
-        LibTypes.SelectedArchaeologistMemory[] memory sarcoArchaeologists,
+        LibTypes.SelectedArchaeologistMemory[] memory selectedArchaeologists,
         address arweaveArchaeologist
     ) external returns (uint256) {
         // Confirm that this exact sarcophagus does not already exist
@@ -75,7 +75,7 @@ contract EmbalmerFacet {
             revert LibErrors.SarcophagusAlreadyExists(sarcoId);
         }
 
-        // Confirm that the ressurection time is in the future
+        // Confirm that the resurrection time is in the future
         if (sarcophagus.resurrectionTime <= block.timestamp) {
             revert LibErrors.ResurrectionTimeInPast(
                 sarcophagus.resurrectionTime
@@ -83,12 +83,12 @@ contract EmbalmerFacet {
         }
 
         // Confirm that archaeologists are provided
-        if (sarcoArchaeologists.length == 0) {
+        if (selectedArchaeologists.length == 0) {
             revert LibErrors.NoArchaeologistsProvided();
         }
 
         // Confirm that minShards is less than the number of archaeologists
-        if (sarcophagus.minShards > sarcoArchaeologists.length) {
+        if (sarcophagus.minShards > selectedArchaeologists.length) {
             revert LibErrors.MinShardsGreaterThanArchaeologists(
                 sarcophagus.minShards
             );
@@ -102,7 +102,7 @@ contract EmbalmerFacet {
         // Initialize a list of archaeologist addresses to be passed in to the
         // sarcophagus object
         address[] memory archaeologistsToBond = new address[](
-            sarcoArchaeologists.length
+            selectedArchaeologists.length
         );
 
         // Initialize the storage fee of the archaeologist who uploades to
@@ -110,8 +110,8 @@ contract EmbalmerFacet {
         // sarcophagus object.
         uint256 storageFee = 0;
 
-        for (uint256 i = 0; i < sarcoArchaeologists.length; i++) {
-            LibTypes.SelectedArchaeologistMemory memory arch = sarcoArchaeologists[i];
+        for (uint256 i = 0; i < selectedArchaeologists.length; i++) {
+            LibTypes.SelectedArchaeologistMemory memory arch = selectedArchaeologists[i];
 
             // Confirm that the archaeologist list is unique. This is done by
             // checking that the archaeologist does not already exist from

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -28,7 +28,7 @@ contract ViewStateFacet {
         view
         returns (uint256)
     {
-        return s.freeBonds[archaeologist];
+        return s.archaeologistProfiles[archaeologist].freeBond;
     }
 
     /// @notice Returns the amount of rewards stored in the contract for an
@@ -52,7 +52,7 @@ contract ViewStateFacet {
         view
         returns (uint256)
     {
-        return s.cursedBonds[archaeologist];
+        return s.archaeologistProfiles[archaeologist].cursedBond;
     }
 
     function getArchaeologistSuccessOnSarcophagus(

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -19,6 +19,30 @@ contract ViewStateFacet {
         return s.protocolFee;
     }
 
+    /// @notice Given an archaeologist address, return that archaeologist's
+    /// profile
+    /// @param archaeologist The archaeologist account's address
+    /// @return the Archaeologist object
+    function getArchaeologistProfile(address archaeologist)
+        external
+        view
+        returns (LibTypes.ArchaeologistProfile memory)
+    {
+        return s.archaeologistProfiles[archaeologist];
+    }
+
+    /// @notice Given an index (of the full archaeologist array), return the
+    /// archaeologist address at that index
+    /// @param index The index of the registered archaeologist
+    /// @return address of the archaeologist
+    function getArchaeologistProfileAddressAtIndex(uint256 index)
+        external
+        view
+        returns (address)
+    {
+        return s.archaeologistProfileAddresses[index];
+    }
+
     /// @notice Returns the amount of free bond stored in the contract for an
     /// archaeologist.
     /// @param archaeologist The address of the archaeologist whose
@@ -98,7 +122,7 @@ contract ViewStateFacet {
     /// sarcophagi that the embalmer has created.
     /// @param embalmer The address of the embalmer whose sarcophagi are being
     /// returned
-    function getEmbalmersarcophagi(address embalmer)
+    function getEmbalmerSarcophagi(address embalmer)
         external
         view
         returns (bytes32[] memory)
@@ -110,7 +134,7 @@ contract ViewStateFacet {
     /// sarcophagi that the archaeologist has participated in.
     /// @param archaeologist The address of the archaeologist whose sarcophagi
     /// are being returned
-    function getArchaeologistsarcophagi(address archaeologist)
+    function getArchaeologistSarcophagi(address archaeologist)
         external
         view
         returns (bytes32[] memory)
@@ -122,7 +146,7 @@ contract ViewStateFacet {
     /// sarcophagi that the recipient has participated in.
     /// @param recipient The address of the recipient whose sarcophagi are being
     /// returned
-    function getRecipientsarcophagi(address recipient)
+    function getRecipientSarcophagi(address recipient)
         external
         view
         returns (bytes32[] memory)

--- a/contracts/libraries/LibBonds.sol
+++ b/contracts/libraries/LibBonds.sol
@@ -32,15 +32,15 @@ library LibBonds {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
         // Revert if the amount is greater than the current free bond
-        if (amount > s.freeBonds[archaeologist]) {
+        if (amount > s.archaeologistProfiles[archaeologist].freeBond) {
             revert LibErrors.NotEnoughFreeBond(
-                s.freeBonds[archaeologist],
+                s.archaeologistProfiles[archaeologist].freeBond,
                 amount
             );
         }
 
         // Decrease the free bond amount
-        s.freeBonds[archaeologist] -= amount;
+        s.archaeologistProfiles[archaeologist].freeBond -= amount;
     }
 
     /// @notice Increases the amount stored in the freeBond mapping for an
@@ -52,7 +52,7 @@ library LibBonds {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
         // Increase the free bond amount
-        s.freeBonds[archaeologist] += amount;
+        s.archaeologistProfiles[archaeologist].freeBond += amount;
     }
 
     /// @notice Decreases the amount stored in the cursedBond mapping for an
@@ -67,15 +67,15 @@ library LibBonds {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
         // Revert if the amount is greater than the current cursed bond
-        if (amount > s.cursedBonds[archaeologist]) {
+        if (amount > s.archaeologistProfiles[archaeologist].cursedBond) {
             revert LibErrors.NotEnoughCursedBond(
-                s.cursedBonds[archaeologist],
+                s.archaeologistProfiles[archaeologist].cursedBond,
                 amount
             );
         }
 
         // Decrease the cursed bond amount
-        s.cursedBonds[archaeologist] -= amount;
+        s.archaeologistProfiles[archaeologist].cursedBond -= amount;
     }
 
     /// @notice Increases the amount stored in the cursedBond mapping for an
@@ -89,7 +89,7 @@ library LibBonds {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
         // Increase the cursed bond amount
-        s.cursedBonds[archaeologist] += amount;
+        s.archaeologistProfiles[archaeologist].cursedBond += amount;
     }
 
     /// @notice Locks up the archaeologist's bond, decreasing the
@@ -194,7 +194,7 @@ library LibBonds {
             archaeologistData.bounty
         );
 
-        // Lock up the archaeologist's bond by the cursed bond amount
+        // Free up the archaeologist's locked bond
         unlockBond(archaeologist, cursedBondAmount);
     }
 }

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -13,7 +13,7 @@ library LibErrors {
 
     error ArchaeologistNotOnSarcophagus(address archaeologist);
 
-    error ArchaeologistProfileExistsIs(bool exists, address archaeologist);
+    error ArchaeologistProfileExistsShouldBe(bool exists, address archaeologist);
 
     error ArweaveArchaeologistNotInList();
 

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -13,6 +13,8 @@ library LibErrors {
 
     error ArchaeologistNotOnSarcophagus(address archaeologist);
 
+    error ArchaeologistProfileExistsIs(bool exists, address archaeologist);
+
     error ArweaveArchaeologistNotInList();
 
     error ArweaveTxIdEmpty();

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -67,6 +67,16 @@ library LibTypes {
         uint256 curseTokenId;
     }
 
+    // ArchaeologistProfile is used to store archaeologist profile data
+    struct ArchaeologistProfile {
+        bool exists;
+        uint256 minimumDiggingFee;
+        uint256 maximumResurrectionInterval;
+        uint256 freeBond;
+        uint256 cursedBond;
+        uint256 rewards;
+    }
+
     struct SarcophagusMemory {
         string name;
         address recipient;

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -15,7 +15,7 @@ library LibTypes {
     }
 
     // A struct of just the signature. This is used primarily by the
-    // finalizeSarcpohagus function for the arweave archaeologist. Note that,
+    // finalizeSarcophagus function for the arweave archaeologist. Note that,
     // unlike the regular archaeologists, the sarcophagus already stores the
     // single arweave archaeologist's address so there is no need to pass in the
     // address to the finalizeSarcophagus function.
@@ -36,12 +36,12 @@ library LibTypes {
         bytes32 s;
     }
 
-    // ArchaeologistMemory is the struct that is passed into the
+    // SelectedArchaeologistMemory is the struct that is passed into the
     // initializeSarcophagus function. Even though we don't need each storage
     // fee of the archaeologist, the storage fee is included in the struct to
     // reduce the stack size within the function, preventing the "stack too
     // deep" error.
-    struct ArchaeologistMemory {
+    struct SelectedArchaeologistMemory {
         address archAddress;
         uint256 storageFee;
         uint256 diggingFee;
@@ -55,7 +55,7 @@ library LibTypes {
     // The archaeologist address is left out since each archaeologist's address
     // is stored on the sarcophagus object as an array.
     //
-    // The storage fee is left out becuase we only need to store the storage fee
+    // The storage fee is left out because we only need to store the storage fee
     // of the archaeologist uploading to arweave, which will be stored directly
     // on the sarcophagus.
     struct ArchaeologistStorage {

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -71,7 +71,7 @@ library LibTypes {
     struct ArchaeologistProfile {
         bool exists;
         uint256 minimumDiggingFee;
-        uint256 maximumResurrectionInterval;
+        uint256 maximumRewrapInterval;
         uint256 freeBond;
         uint256 cursedBond;
         uint256 rewards;

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -266,26 +266,24 @@ library LibUtils {
                 .doubleHashedShard != 0;
     }
 
-    /**
-     * @notice Checks if an archaeologist profile exists and
-     * reverts if it does not
-     * @param account the archaeologist address to check existence of
-     */
     function revertIfArchProfileIs(bool existing, address archaeologist)
         internal
         view
     {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
-        // revert if necessary
-        if (existing ? !s.ArchaeologistProfiles[archaeologist] : s.ArchaeologistProfiles[archaeologist]) {
-            revert LibErrors.ArchaeologistProfileExistsIs(
-                existing,
+        if (existing ? s.archaeologistProfiles[archaeologist].exists : !s.archaeologistProfiles[archaeologist].exists) {
+            revert LibErrors.ArchaeologistProfileExistsShouldBe(
+                !existing,
                 archaeologist
             );
         }
     }
 
+    /// @notice Checks if an archaeologist profile exists and
+    /// reverts if so
+    ///
+    /// @param archaeologist the archaeologist address to check existence of
     function revertIfArchProfileExists(address archaeologist)
         internal
         view
@@ -293,6 +291,10 @@ library LibUtils {
         revertIfArchProfileIs(true, archaeologist);
     }
 
+    /// @notice Checks if an archaeologist profile doesn't exist and
+    /// reverts if so
+    ///
+    /// @param archaeologist the archaeologist address to check lack of existence of
     function revertIfArchProfileDoesNotExist(address archaeologist)
         internal
         view

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -266,6 +266,40 @@ library LibUtils {
                 .doubleHashedShard != 0;
     }
 
+    /**
+     * @notice Checks if an archaeologist profile exists and
+     * reverts if it does not
+     * @param account the archaeologist address to check existence of
+     */
+    function revertIfArchProfileIs(bool existing, address archaeologist)
+        internal
+        view
+    {
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        // revert if necessary
+        if (existing ? !s.ArchaeologistProfiles[archaeologist] : s.ArchaeologistProfiles[archaeologist]) {
+            revert LibErrors.ArchaeologistProfileExistsIs(
+                existing,
+                archaeologist
+            );
+        }
+    }
+
+    function revertIfArchProfileExists(address archaeologist)
+        internal
+        view
+    {
+        revertIfArchProfileIs(true, archaeologist);
+    }
+
+    function revertIfArchProfileDoesNotExist(address archaeologist)
+        internal
+        view
+    {
+        revertIfArchProfileIs(false, archaeologist);
+    }
+
     /// @notice Gets an archaeologist given the sarcophagus identifier and the
     /// archaeologist's address.
     /// @param sarcoId the identifier of the sarcophagus

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -19,6 +19,9 @@ struct AppStorage {
     // Each archaeologist's total free and cursed bonds
     mapping(address => uint256) freeBonds;
     mapping(address => uint256) cursedBonds;
+    // archaeologist profiles
+    address[] archaeologistProfileAddresses;
+    mapping(address => LibTypes.ArchaeologistProfile) archaeologistProfiles;
     // archaeologist stats
     mapping(address => mapping(bytes32 => bool)) archaeologistSuccesses;
     mapping(address => bytes32[]) archaeologistCancels;

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -26,7 +26,7 @@ struct AppStorage {
     mapping(address => bytes32[]) archaeologistCleanups;
     // Track how much archaeologists have made. To be credited and debited
     // as archaeologists fulfil their duties and withdraw their rewards
-    // TODO use archaelogistProfiles for rewards instead
+    // TODO use archaeologistProfiles for rewards instead
     mapping(address => uint256) archaeologistRewards;
     mapping(bytes32 => LibTypes.Sarcophagus) sarcophagi;
     // sarcophagus ownerships

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -16,9 +16,6 @@ struct AppStorage {
     uint256 totalProtocolFees;
     // sarcophagi
     bytes32[] sarcophagusIdentifiers;
-    // Each archaeologist's total free and cursed bonds
-    mapping(address => uint256) freeBonds;
-    mapping(address => uint256) cursedBonds;
     // archaeologist profiles
     address[] archaeologistProfileAddresses;
     mapping(address => LibTypes.ArchaeologistProfile) archaeologistProfiles;
@@ -29,6 +26,7 @@ struct AppStorage {
     mapping(address => bytes32[]) archaeologistCleanups;
     // Track how much archaeologists have made. To be credited and debited
     // as archaeologists fulfil their duties and withdraw their rewards
+    // TODO use archaelogistProfiles for rewards instead
     mapping(address => uint256) archaeologistRewards;
     mapping(bytes32 => LibTypes.Sarcophagus) sarcophagi;
     // sarcophagus ownerships

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "description": "[![Discord](https://img.shields.io/discord/753398645507883099?color=768AD4&label=discord)](https://discord.com/channels/753398645507883099/) [![Twitter](https://img.shields.io/twitter/follow/sarcophagusio?style=social)](https://twitter.com/sarcophagusio)",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified. Use `npx hardhat test`\" && exit 1"
+    "test": "npx hardhat test",
+    "compile": "npx hardhat compile"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -1,5 +1,5 @@
-import { ContractTransaction } from "ethers";
-import { deployments } from "hardhat";
+import { BigNumber, ContractTransaction } from "ethers";
+import { deployments, ethers } from "hardhat";
 import {
   ArchaeologistFacet,
   CursesMock,
@@ -124,7 +124,11 @@ export const createSarcoFixture = (
 
           await sarcoToken.connect(acc).approve(diamond.address, ethers.constants.MaxUint256);
 
-          await archaeologistFacet.connect(acc).depositFreeBond(ethers.utils.parseEther("5000"));
+          await archaeologistFacet.connect(acc).registerArchaeologist(
+            ethers.utils.parseEther("10"),
+            BigNumber.from("1000"),
+            ethers.utils.parseEther("5000")
+          );
         }
       }
 

--- a/test/fixtures/spawn-archaeologists.ts
+++ b/test/fixtures/spawn-archaeologists.ts
@@ -62,7 +62,11 @@ export async function spawnArchaologistsWithSignatures(
     await sarcoToken.connect(acc).approve(diamondAddress, ethers.constants.MaxUint256);
 
     // Deposit 5000 tokens for each archaeologist so they're ready to be bonded
-    await archaeologistFacet.connect(acc).depositFreeBond(ethers.utils.parseEther("5000"));
+    await archaeologistFacet.connect(acc).registerArchaeologist(
+      ethers.utils.parseEther("10"),
+      BigNumber.from("1000"),
+      ethers.utils.parseEther("5000")
+    );
 
     signatures.push({ ...signature, account: acc.address });
   }

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -140,3 +140,19 @@ export const registerArchaeologist = async (
       BigNumber.from(freeBond)
     );
 }
+
+export const updateArchaeologist = async (
+  archaeologist: TestArchaeologist,
+  archaeologistFacet: ArchaeologistFacet,
+  minDiggingFee: string,
+  minRewrapInterval: string,
+  freeBond?: string
+): Promise<void> => {
+  await archaeologistFacet
+    .connect(archaeologist.signer)
+    .updateArchaeologist(
+      BigNumber.from(minDiggingFee),
+      BigNumber.from(minRewrapInterval),
+      BigNumber.from(freeBond || 0)
+    );
+}

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,8 +1,9 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber, Signature } from "ethers";
 import { ethers } from "hardhat";
-import { SarcoTokenMock, ViewStateFacet } from "../../typechain";
+import { ArchaeologistFacet, SarcoTokenMock, ViewStateFacet } from "../../typechain";
 import { SignatureWithAccount } from "../../types";
+import { TestArchaeologist } from "../fixtures/spawn-archaeologists";
 
 /**
  * Signs a message as any EVM compatible type and returns the signature and the
@@ -119,3 +120,23 @@ export const getAttributeFromURI = (uri: string, attributeName: string): number 
   ).value;
   return parseInt(resurrectionTime);
 };
+
+export const registerArchaeologist = async (
+  archaeologist: TestArchaeologist,
+  archaeologistFacet: ArchaeologistFacet,
+  minDiggingFee?: string,
+  minRewrapInterval?: string,
+  freeBond?: string
+): Promise<void> => {
+  freeBond = freeBond || "0";
+  minDiggingFee = minDiggingFee || "100";
+  minRewrapInterval = minRewrapInterval || "10000";
+
+  await archaeologistFacet
+    .connect(archaeologist.signer)
+    .registerArchaeologist(
+      BigNumber.from(minDiggingFee),
+      BigNumber.from(minRewrapInterval),
+      BigNumber.from(freeBond)
+    );
+}


### PR DESCRIPTION
## Overview

Adds registering / updating of archaeologist profiles to the contract. This will allow `initializeSarcophagus` and `finalizeSarcophagus` to be combined into a single function in a followup PR.

Currently there are 2 profile values that can be updated:
`minimumDiggingFee`
`maximumRewrapInterval`

`freeBond` can optionally also be passed in if the archaeologist wants to deposit free bond when they register/update. They can also opt to not pass in a free bond and deposit free bond separately.

## TODO
We need to examine whether the `encryptionPublicKey` should be added to the profile or not. The system can function without this update, but it should be discussed further.