### PR TITLE
remove bounty

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -207,10 +207,10 @@ contract ArchaeologistFacet {
         // Save the successful sarcophagus against the archaeologist
         s.archaeologistSuccesses[msg.sender][sarcoId] = true;
 
-        // Transfer the bounty and digging fee to the archaeologist's reward pool
+        // Transfer the digging fee to the archaeologist's reward pool
         LibRewards.increaseRewardPool(
             msg.sender,
-            archaeologistData.bounty + archaeologistData.diggingFee
+            archaeologistData.diggingFee
         );
 
         // Emit an event
@@ -288,14 +288,12 @@ contract ArchaeologistFacet {
 
         // Add the new archaeologist's address to the sarcohpagusArchaeologists mapping
         newArchData.diggingFee = oldArchData.diggingFee;
-        newArchData.bounty = oldArchData.bounty;
         newArchData.doubleHashedShard = oldArchData.doubleHashedShard;
         newArchData.unencryptedShard = "";
 
         // Set the old archaeologist's data in the sarcophagusArchaeologists
         // mapping to their default values
         oldArchData.diggingFee = 0;
-        oldArchData.bounty = 0;
         oldArchData.doubleHashedShard = 0;
         oldArchData.unencryptedShard = "";
 

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -44,7 +44,7 @@ contract EmbalmerFacet {
     /// process.
     ///
     /// The purpose of initializeSarcophagus is to:
-    ///   - Lock up payment for the archaeologists (bounty, digging fees, and storage fee)
+    ///   - Lock up payment for the archaeologists (digging fees)
     ///   - Store hashes of the unencrypted shards on chain
     ///   - Store the participating archaeologists' addresses and individual
     ///     denominations of fees dedicated to each
@@ -133,7 +133,6 @@ contract EmbalmerFacet {
             LibTypes.ArchaeologistStorage memory archaeologistStorage = LibTypes
                 .ArchaeologistStorage({
                     diggingFee: arch.diggingFee,
-                    bounty: arch.bounty,
                     diggingFeesPaid: 0,
                     doubleHashedShard: doubleHashedShard,
                     unencryptedShard: "",
@@ -144,7 +143,7 @@ contract EmbalmerFacet {
             s.doubleHashedShardArchaeologists[doubleHashedShard] = arch
                 .archAddress;
 
-            // Stores each archaeologist's bounty, digging fees, and unencrypted
+            // Stores each archaeologist's digging fees and unencrypted
             // shard in app storage per sarcophagus
             s.sarcophagusArchaeologists[sarcoId][
                 arch.archAddress
@@ -554,10 +553,6 @@ contract EmbalmerFacet {
         // Set sarcophagus state to done
         s.sarcophagi[sarcoId].state = LibTypes.SarcophagusState.Done;
 
-        // Total bounty will be added up when we loop through the
-        // archaeologists. This will be sent back to the embalmer.
-        uint256 totalBounty = 0;
-
         // For each archaeologist on the sarcophagus,
         // 1. Unlock their cursed bond
         // 2. Transfer digging fees to the archaeologist.
@@ -577,13 +572,7 @@ contract EmbalmerFacet {
                 bondedArchaeologists[i],
                 archaeologistData.diggingFee
             );
-
-            // Add the archaeoogist's bounty to totalBounty
-            totalBounty += archaeologistData.bounty;
         }
-
-        // Transfer the total bounty back to the embalmer (msg.sender)
-        s.sarcoToken.transfer(msg.sender, totalBounty);
 
         // Emit an event
         emit BurySarcophagus(sarcoId);

--- a/contracts/interfaces/ICurses.sol
+++ b/contracts/interfaces/ICurses.sol
@@ -34,7 +34,7 @@ interface ICurses {
         bytes memory _traitValue
     ) external;
 
-    function createSVG(uint256 bounty, uint256 diggingFee)
+    function createSVG(uint256 diggingFee)
         external
         pure
         returns (string memory);

--- a/contracts/libraries/LibBonds.sol
+++ b/contracts/libraries/LibBonds.sol
@@ -8,18 +8,18 @@ import {LibErrors} from "../libraries/LibErrors.sol";
 library LibBonds {
     /// @notice Calculates the cursed bond that an archaeologist needs to lock
     /// up
-    /// @dev The cursed bond amount is the sum of the digging fee and the
-    /// bounty.
+    /// @dev The cursed bond amount is the digging fee
     /// @param diggingFee The digging fee of the sarcophagus
-    /// @param bounty The bounty of the sarcophagus
     /// @return The amount of cursed bond
-    function calculateCursedBond(uint256 diggingFee, uint256 bounty)
+    function calculateCursedBond(uint256 diggingFee)
         internal
         pure
         returns (uint256)
     {
-        // TODO: Implement a better algorithm for calculating the cursed bond
-        return diggingFee + bounty;
+        // TODO: We dont need this function unless we implement a better algorithm
+        // for calculating the cursed bond
+        // Anywhere this method is used should be replaced with just the digging fee
+        return diggingFee;
     }
 
     /// @notice Decreases the amount stored in the freeBond mapping for an
@@ -119,9 +119,7 @@ library LibBonds {
     }
 
     /// @notice Given an array of archaeologists on a sarcophagus, sums the total of
-    /// 1. Each archaeologists' bounty
-    /// 2. Each archaeologists' digging fees
-    /// 3. The storage fee
+    /// 1. Each archaeologists' digging fees
     /// @param sarcoId The identifier of the sarcophagus
     /// @param archaeologists The array of archaeologists' addresses
     /// @return the total of the above
@@ -138,15 +136,9 @@ library LibBonds {
             LibTypes.ArchaeologistStorage memory archaeologistsData = s
                 .sarcophagusArchaeologists[sarcoId][archaeologists[i]];
 
-            // add the archaeologist's bounty to the total fees
-            totalFees += archaeologistsData.bounty;
-
             // add the archaeologist's digging fee to the total fees
             totalFees += archaeologistsData.diggingFee;
         }
-
-        // add the storage fee to the total fees
-        totalFees += s.sarcophagi[sarcoId].storageFee;
 
         // return the total fees
         return totalFees;
@@ -167,8 +159,7 @@ library LibBonds {
 
         // Calculate the amount of cursed bond the archaeologists needs to lock up
         uint256 cursedBondAmount = calculateCursedBond(
-            archaeologistData.diggingFee,
-            archaeologistData.bounty
+            archaeologistData.diggingFee
         );
 
         // Lock up the archaeologist's bond by the cursed bond amount
@@ -190,8 +181,7 @@ library LibBonds {
 
         // Calculate the amount of cursed bond the archaeologists needs to lock up
         uint256 cursedBondAmount = calculateCursedBond(
-            archaeologistData.diggingFee,
-            archaeologistData.bounty
+            archaeologistData.diggingFee
         );
 
         // Free up the archaeologist's locked bond

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -45,7 +45,6 @@ library LibTypes {
         address archAddress;
         uint256 storageFee;
         uint256 diggingFee;
-        uint256 bounty;
         bytes32 hashedShard;
     }
 
@@ -60,7 +59,6 @@ library LibTypes {
     // on the sarcophagus.
     struct ArchaeologistStorage {
         uint256 diggingFee;
-        uint256 bounty;
         uint256 diggingFeesPaid;
         bytes32 doubleHashedShard;
         bytes unencryptedShard;
@@ -109,7 +107,6 @@ library LibTypes {
     struct MetadataAttributes {
         string sarcophagusName;
         uint256 diggingFee;
-        uint256 bounty;
         uint256 resurrectionTime;
         uint256 diggingFeesPaid;
     }

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -368,7 +368,6 @@ library LibUtils {
         LibTypes.MetadataAttributes memory attr = LibTypes.MetadataAttributes(
             s.sarcophagi[sarcoId].name,
             s.sarcophagusArchaeologists[sarcoId][archaeologist].diggingFee,
-            s.sarcophagusArchaeologists[sarcoId][archaeologist].bounty,
             s.sarcophagi[sarcoId].resurrectionTime,
             s.sarcophagusArchaeologists[sarcoId][archaeologist].diggingFeesPaid
         );

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -41,9 +41,9 @@ struct AppStorage {
     // Bounty, digging fees, storage fees, and the hashed shards of the
     // archaeologists all need to be stored per sarcophagus. This mapping of a
     // mapping stores the archaeologist's data we need per sarcophagus.
-    // Example usage (to retrieve the bounty an archaeologist may claim on some sarcophagus):
+    // Example usage (to retrieve the digging fees an archaeologist may claim on some sarcophagus):
     //   LibTypes.ArchaeologistStorage bondedArchaeologist = sarcophagusArchaeologists[sarcoId][archAddress];
-    //   uint256 bounty = bondedArchaeologist.bounty;
+    //   uint256 diggingFees = bondedArchaeologist.diggingFees;
     mapping(bytes32 => mapping(address => LibTypes.ArchaeologistStorage)) sarcophagusArchaeologists;
 }
 

--- a/contracts/tokens/CursesMock.sol
+++ b/contracts/tokens/CursesMock.sol
@@ -28,7 +28,6 @@ contract CursesMock is ERC1155OnChainMetadata, Ownable, ICurses {
         LibTypes.MetadataAttributes memory attr = LibTypes.MetadataAttributes(
             "First Test",
             1,
-            2,
             0,
             0
         );
@@ -85,7 +84,7 @@ contract CursesMock is ERC1155OnChainMetadata, Ownable, ICurses {
         setValue(
             _tokenId,
             KEY_TOKEN_IMAGE,
-            abi.encode(createSVG(_attr.bounty, _attr.diggingFee))
+            abi.encode(createSVG(_attr.diggingFee))
         );
 
         // Set up the array for attributes
@@ -99,29 +98,23 @@ contract CursesMock is ERC1155OnChainMetadata, Ownable, ICurses {
         values[0] = abi.encodePacked(Strings.toString(_attr.diggingFee));
         attributeIndexes[traitTypes[0]] = 0;
 
-        // Bounty
-        traitTypes[1] = abi.encodePacked("Bounty");
-        displayTypes[1] = abi.encodePacked("number");
-        values[1] = abi.encodePacked(Strings.toString(_attr.bounty));
+        // Sarcophagus name
+        traitTypes[1] = abi.encodePacked("SarcophagusName");
+        displayTypes[1] = abi.encodePacked("string");
+        values[1] = abi.encodePacked(_attr.sarcophagusName);
         attributeIndexes[traitTypes[1]] = 1;
 
-        // Sarcophagus name
-        traitTypes[2] = abi.encodePacked("SarcophagusName");
-        displayTypes[2] = abi.encodePacked("string");
-        values[2] = abi.encodePacked(_attr.sarcophagusName);
+        // Resurrection time
+        traitTypes[2] = abi.encodePacked("Resurrection Time");
+        displayTypes[2] = abi.encodePacked("number");
+        values[2] = abi.encodePacked(Strings.toString(_attr.resurrectionTime));
         attributeIndexes[traitTypes[2]] = 2;
 
-        // Resurrection time
-        traitTypes[3] = abi.encodePacked("Resurrection Time");
-        displayTypes[3] = abi.encodePacked("number");
-        values[3] = abi.encodePacked(Strings.toString(_attr.resurrectionTime));
-        attributeIndexes[traitTypes[3]] = 3;
-
         // Digging fees collected
-        traitTypes[4] = abi.encodePacked("Digging Fees Paid");
-        displayTypes[4] = abi.encodePacked("string");
-        values[4] = abi.encodePacked(Strings.toString(_attr.diggingFeesPaid));
-        attributeIndexes[traitTypes[4]] = 4;
+        traitTypes[3] = abi.encodePacked("Digging Fees Paid");
+        displayTypes[3] = abi.encodePacked("string");
+        values[3] = abi.encodePacked(Strings.toString(_attr.diggingFeesPaid));
+        attributeIndexes[traitTypes[3]] = 3;
 
         // Save the attributes to the contract
         setValues(_tokenId, KEY_TOKEN_ATTRIBUTES_TRAIT_TYPE, traitTypes);
@@ -167,13 +160,11 @@ contract CursesMock is ERC1155OnChainMetadata, Ownable, ICurses {
 
     // prettier-ignore
     /// @notice Generates a SVG image for the token based on the passed in attributes.
-    /// @param _bounty the bounty of the token.
     /// @param _diggingFee the digging fee of the token.
     /// @return the SVG image for the token as a string.
-    function createSVG(uint256 _bounty, uint256 _diggingFee) public pure returns (string memory) {
+    function createSVG(uint256 _diggingFee) public pure returns (string memory) {
         return string( abi.encodePacked("data:image/svg+xml;base64,", Base64.encode(bytes(string(abi.encodePacked(
-            "<svg style='background-color:#000' viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'><text transform='translate(23.246 137.01)' dx='0' dy='0' fill='#ffffff' font-size='15' font-weight='400'>Sarcophagus</text><text transform='translate(23.246 176.56)' dx='0' dy='0' fill='#a6a6a6' font-size='8' font-weight='400' stroke-width='0'>Digging fee:</text><text transform='translate(23.246 162.56)' dx='0' dy='0' fill='#a6a6a6' font-size='8' font-weight='400' stroke-width='0'>Bounty:</text><text transform='translate(91.246 162.56)' dx='0' dy='0' fill='#a6a6a6' font-size='8' font-weight='400' stroke-width='0'>",
-            Strings.toString(_bounty),
+            "<svg style='background-color:#000' viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'><text transform='translate(23.246 137.01)' dx='0' dy='0' fill='#ffffff' font-size='15' font-weight='400'>Sarcophagus</text><text transform='translate(23.246 176.56)' dx='0' dy='0' fill='#a6a6a6' font-size='8' font-weight='400' stroke-width='0'>Digging fee:</text><text transform='translate(23.246 162.56)' dx='0' dy='0' fill='#a6a6a6' font-size='8' font-weight='400' stroke-width='0'>",
             " SARCO</text><text transform='translate(91.246 176.56)' dx='0' dy='0' fill='#a6a6a6' font-size='8' font-weight='400' stroke-width='0'>",
             Strings.toString(_diggingFee),
             " SARCO</text></svg>"

--- a/test/facets/archaeologist-facet.spec.ts
+++ b/test/facets/archaeologist-facet.spec.ts
@@ -435,7 +435,7 @@ describe("Contract: ArchaeologistFacet", () => {
 
         // Check that the cursed bond amount has been freed up.
         expect(cursedBondAmountBefore).to.equal(
-          calculateCursedBond(archaeologists[0].diggingFee, archaeologists[0].bounty)
+          calculateCursedBond(archaeologists[0].diggingFee)
         );
         expect(cursedBondAmountAfter).to.equal(0);
       });
@@ -461,12 +461,12 @@ describe("Contract: ArchaeologistFacet", () => {
         expect(isSuccessfulSarcophagus).to.be.true;
       });
 
-      it("should transfer the digging fee and bounty to the archaeologist's reward pool without transferring tokens", async () => {
+      it("should transfer the digging fee to the archaeologist's reward pool without transferring tokens", async () => {
         const { archaeologists, archaeologistFacet, sarcoId, sarcoToken, viewStateFacet } =
           await createSarcoFixture({ shares, threshold }, "Test Sarco");
 
-        // Calculate the digging fee and bounty for the first archaeologist
-        const totalFees = archaeologists[0].diggingFee.add(archaeologists[0].bounty);
+        // Calculate the digging fee for the first archaeologist
+        const totalFees = archaeologists[0].diggingFee;
 
         // Get the sarco balance of the first archaeologist before unwrap
         const sarcoBalanceBefore = await sarcoToken.balanceOf(archaeologists[0].archAddress);
@@ -718,7 +718,6 @@ describe("Contract: ArchaeologistFacet", () => {
 
         expect(oldArchaeologistData.doubleHashedShard).to.equal(ethers.constants.HashZero);
         expect(oldArchaeologistData.diggingFee).to.equal("0");
-        expect(oldArchaeologistData.bounty).to.equal("0");
       });
 
       it("should add the arweave transaction id to the list of arweaveTxIds on the sarcophagus", async () => {

--- a/test/facets/embalmer-facet.spec.ts
+++ b/test/facets/embalmer-facet.spec.ts
@@ -29,22 +29,19 @@ describe("Contract: EmbalmerFacet", () => {
 
         const embalmerBalanceAfter = await sarcoToken.balanceOf(embalmer.address);
 
-        // Calculate the total fees:
-        // The arweaver archaeologist's storage fee + all bounties + all digging
-        // fees
+        // Calculate the total fees (all digging fees)
         const totalFees = archaeologists
           .reduce(
-            (acc, arch) => acc.add(calculateCursedBond(arch.diggingFee, arch.bounty)),
+            (acc, arch) => acc.add(calculateCursedBond(arch.diggingFee)),
             BigNumber.from("0")
-          )
-          .add(arweaveArchaeologist.storageFee);
+          );
 
         expect(embalmerBalanceAfter.toString()).to.equal(
           embalmerBalanceBefore.sub(totalFees).toString()
         );
       });
 
-      it("should emit InitializeSarcophagust()", async () => {
+      it("should emit InitializeSarcophagus()", async () => {
         const { embalmerFacet, initializeTx } = await createSarcoFixture(
           { shares, threshold, skipFinalize: true },
           sarcoName
@@ -324,8 +321,7 @@ describe("Contract: EmbalmerFacet", () => {
         );
 
         const bondAmount = calculateCursedBond(
-          regularArchaeologist.diggingFee,
-          regularArchaeologist.bounty
+          regularArchaeologist.diggingFee
         );
 
         // Check that the archaeologist's free bond afterward has descreased by the bond amount
@@ -368,8 +364,7 @@ describe("Contract: EmbalmerFacet", () => {
         );
 
         const bondAmount = calculateCursedBond(
-          arweaveArchaeologist.diggingFee,
-          arweaveArchaeologist.bounty
+          arweaveArchaeologist.diggingFee
         );
 
         // Check that the arweave archaeologist's free bond has decreased by the bond amount
@@ -628,7 +623,7 @@ describe("Contract: EmbalmerFacet", () => {
         expect(tx).to.emit(embalmerFacet, "RewrapSarcophagus");
       });
 
-      it("should update the ressurection time on the curse nft", async () => {
+      it("should update the resurrection time on the curse nft", async () => {
         const { tx, curses, archaeologists, viewStateFacet, sarcoId, newResurrectionTime } =
           await rewrapFixture({ shares, threshold }, sarcoName);
         await tx;
@@ -661,7 +656,7 @@ describe("Contract: EmbalmerFacet", () => {
         await tx;
 
         // Rewrap a second time
-        const anotherTx = await embalmerFacet
+        await embalmerFacet
           .connect(embalmer)
           .rewrapSarcophagus(sarcoId, newResurrectionTime + 604800);
 
@@ -849,32 +844,15 @@ describe("Contract: EmbalmerFacet", () => {
 
         expect(freeBondAfter.toString()).to.equal(
           regularArchaeologistFreeBondBefore
-            .add(calculateCursedBond(regularArchaeologist.diggingFee, regularArchaeologist.bounty))
+            .add(calculateCursedBond(regularArchaeologist.diggingFee))
             .toString()
         );
 
         expect(cursedBondAfter.toString()).to.equal(
           regularArchaeologistCursedBondBefore
-            .sub(calculateCursedBond(regularArchaeologist.diggingFee, regularArchaeologist.bounty))
+            .sub(calculateCursedBond(regularArchaeologist.diggingFee))
             .toString()
         );
-      });
-
-      it("should transfer the bounty back to the embalmer", async () => {
-        const { sarcoToken, embalmer, archaeologists, embalmerBalanceBeforeBury } =
-          await buryFixture({ shares, threshold }, sarcoName);
-
-        // Get the archaeologist sarco balance after bury
-        const embalmerBalanceAfter = await sarcoToken.balanceOf(embalmer.address);
-
-        // Add the bounties in archaeologist fees
-        const totalBounty = archaeologists.reduce(
-          (acc, arch) => acc.add(arch.bounty),
-          ethers.constants.Zero
-        );
-
-        // Check that the difference in balances is equal to the total bounty
-        expect(embalmerBalanceAfter.sub(embalmerBalanceBeforeBury)).to.equal(totalBounty);
       });
 
       it("should emit BurySarcophagus()", async () => {

--- a/test/facets/third-party-facet.spec.ts
+++ b/test/facets/third-party-facet.spec.ts
@@ -50,24 +50,23 @@ describe("Contract: ThirdPartyFacet", () => {
         // after cleaning, calculate sum, and verify on exact amounts instead
         // Set up amounts that should have been transferred to accuser and embalmer
         // ie, rewards of failed archaeologists
-        const totalDiggingFeesAndBounty = archaeologists
+        const sumDiggingFees = archaeologists
           .slice(1) // archaeologists[0] did their job, so not included
           .reduce(
-            (acc, arch) => [acc[0].add(arch.diggingFee), acc[1].add(arch.bounty)],
-            [BigNumber.from("0"), BigNumber.from("0")]
+            (acc, arch) => [acc[0].add(arch.diggingFee)],
+            [BigNumber.from("0")]
           );
 
-        const totalDiggingFees = totalDiggingFeesAndBounty[0];
-        const totalBounty = totalDiggingFeesAndBounty[1];
+        const totalDiggingFees = sumDiggingFees[0];
 
-        const cursedBond = calculateCursedBond(totalDiggingFees, totalBounty);
+        const cursedBond = calculateCursedBond(totalDiggingFees);
         const toEmbalmer = cursedBond.div(2);
         const toCleaner = cursedBond.sub(toEmbalmer);
 
         // Check that embalmer and accuser now have balance that includes the amount that should have been transferred to them
 
-        // embalmer should receive half cursed bond, PLUS bounty and digging fees of failed archs
-        const embalmerReward = toEmbalmer.add(totalBounty.add(totalDiggingFees));
+        // embalmer should receive half cursed bond, PLUS digging fees of failed archs
+        const embalmerReward = toEmbalmer.add(totalDiggingFees);
 
         expect(embalmerBalanceAfter.eq(embalmerBalanceBefore.add(embalmerReward))).to.be.true;
         expect(paymentAccountBalanceAfter.eq(paymentAccountBalanceBefore.add(toCleaner))).to.be
@@ -268,7 +267,7 @@ describe("Contract: ThirdPartyFacet", () => {
         expect(sarco.state).to.be.eq(2); // 2 is "Done"
       });
 
-      it("Should distribute half the sum of the accused archaeologists' bounties and digging fees to accuser, and other half to embalmer", async () => {
+      it("Should distribute half the sum of the accused archaeologists' digging fees to accuser, and other half to embalmer", async () => {
         const { archaeologists, sarcoId, thirdParty, thirdPartyFacet, embalmer, sarcoToken } =
           await createSarcoFixture({ shares, threshold }, "Test Sarco");
 
@@ -288,18 +287,16 @@ describe("Contract: ThirdPartyFacet", () => {
         await tx.wait();
 
         // Set up amounts that should have been transferred to accuser and embalmer
-        const totalDiggingFeesBountyCursedBond = accusedArchs.reduce(
+        const totalDiggingFeesCursedBond = accusedArchs.reduce(
           (acc, arch) => [
             acc[0].add(arch.diggingFee),
-            acc[1].add(arch.bounty),
-            acc[2].add(calculateCursedBond(arch.diggingFee, arch.bounty)),
+            acc[1].add(calculateCursedBond(arch.diggingFee)),
           ],
-          [BigNumber.from("0"), BigNumber.from("0"), BigNumber.from("0")]
+          [BigNumber.from("0"), BigNumber.from("0")]
         );
 
-        const totalDiggingFees = totalDiggingFeesBountyCursedBond[0];
-        const totalBounty = totalDiggingFeesBountyCursedBond[1];
-        const totalCursedBond = totalDiggingFeesBountyCursedBond[2];
+        const totalDiggingFees = totalDiggingFeesCursedBond[0];
+        const totalCursedBond = totalDiggingFeesCursedBond[1];
 
         const toEmbalmer = totalCursedBond.div(2);
         const toAccuser = totalCursedBond.sub(toEmbalmer);
@@ -309,8 +306,8 @@ describe("Contract: ThirdPartyFacet", () => {
 
         // Check that embalmer and accuser now has balance that includes the amount that should have been transferred to them
 
-        // embalmer should receive half cursed bond, PLUS bounty and digging fees of failed archs
-        const embalmerReward = toEmbalmer.add(totalBounty.add(totalDiggingFees));
+        // embalmer should receive half cursed bond, PLUS  digging fees of failed archs
+        const embalmerReward = toEmbalmer.add(totalDiggingFees);
 
         expect(embalmerBalanceAfter.eq(embalmerBalanceBefore.add(embalmerReward))).to.be.true;
         expect(paymentAccountBalanceAfter.eq(paymentAccountBalanceBefore.add(toAccuser))).to.be

--- a/test/fixtures/archaeologists-fixture.ts
+++ b/test/fixtures/archaeologists-fixture.ts
@@ -36,8 +36,7 @@ export const archeologistsFixture = (count: number) =>
           unencryptedShard: [],
           signer: acc,
           storageFee: ethers.utils.parseEther("20"),
-          diggingFee: ethers.utils.parseEther("10"),
-          bounty: ethers.utils.parseEther("100"),
+          diggingFee: ethers.utils.parseEther("10")
         });
 
         // Transfer 10,000 sarco tokens to each archaeologist to be put into free

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -112,8 +112,7 @@ export const createSarcoFixture = (
             unencryptedShard: [],
             signer: acc,
             storageFee: ethers.utils.parseEther("20"),
-            diggingFee: ethers.utils.parseEther("10"),
-            bounty: ethers.utils.parseEther("100"),
+            diggingFee: ethers.utils.parseEther("10")
           });
 
           // Transfer 10,000 sarco tokens to each archaeologist to be put into free

--- a/test/fixtures/finalize-transfer-fixture.ts
+++ b/test/fixtures/finalize-transfer-fixture.ts
@@ -27,12 +27,11 @@ export const finalizeTransferFixture = async () => {
   const oldArchaeologistSignature = await sign(oldArchaeologist, arweaveTxId, "string");
 
   const oldArchaeologistFees = {
-    diggingFee: archaeologists[1].diggingFee,
-    bounty: archaeologists[1].bounty,
+    diggingFee: archaeologists[1].diggingFee
   };
 
   // Calculate the old arch's bond amount
-  const bondAmount = oldArchaeologistFees.bounty.add(oldArchaeologistFees.diggingFee);
+  const bondAmount = oldArchaeologistFees.diggingFee;
 
   // Get the archaeologists cursed, free bond before transfer
   const oldArchaeologistCursedBondBefore = await viewStateFacet.getCursedBond(

--- a/test/fixtures/spawn-archaeologists.ts
+++ b/test/fixtures/spawn-archaeologists.ts
@@ -11,7 +11,6 @@ export interface TestArchaeologist {
   signer: SignerWithAddress;
   storageFee: BigNumber;
   diggingFee: BigNumber;
-  bounty: BigNumber;
   hashedShard: string;
   unencryptedShard: BytesLike;
 }
@@ -20,8 +19,8 @@ export interface TestArchaeologist {
  * Generates and returns [shards.length] archaeologists, each
  * with 10,000 sarco tokens and a 5000-sarco token bond deposit,
  * along with their signatures on the sarcoId. Storage fee,
- * digging fee, and bounty for each generated archaeologist are
- * set to a constanct 20, 10, and 100 sarco tokens respectively.
+ * digging fee for each generated archaeologist are
+ * set to a constant 20, 10, and 100 sarco tokens respectively.
  * */
 export async function spawnArchaologistsWithSignatures(
   shards: Buffer[],
@@ -51,8 +50,7 @@ export async function spawnArchaologistsWithSignatures(
       unencryptedShard: shards[shardI],
       signer: acc,
       storageFee: BigNumber.from("20"),
-      diggingFee: BigNumber.from("10"),
-      bounty: BigNumber.from("100"),
+      diggingFee: BigNumber.from("10")
     });
 
     // Transfer 10,000 sarco tokens to each archaeologist to be put into free

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -106,9 +106,9 @@ export const getArchaeologistSarcoRewards = async (
   return rewards;
 };
 
-// TODO: update if calculate cursed bond algorithm changes (or possibly read this from contract instead?)
-export const calculateCursedBond = (diggingFee: BigNumber, bounty: BigNumber): BigNumber =>
-  diggingFee.add(bounty);
+// TODO: update if calculate cursed bond algorithm changes (or possibly this function will be removed)
+export const calculateCursedBond = (diggingFee: BigNumber): BigNumber =>
+  diggingFee;
 
 export const getAttributeFromURI = (uri: string, attributeName: string): number => {
   const uriPrefix = "data:application/json;base64,";

--- a/types/index.ts
+++ b/types/index.ts
@@ -21,7 +21,6 @@ export interface Archaeologist {
   archAddress: string;
   storageFee: BigNumber;
   diggingFee: BigNumber;
-  bounty: BigNumber;
   hashedShard: string;
 }
 
@@ -34,16 +33,4 @@ export interface DeployedContracts {
   sarcoToken: Contract;
   embalmerFacet: Contract;
   archaeologistFacet: Contract;
-}
-
-export interface FixtureArchaeologist {
-  account: string;
-  // TODO: If archAddress changes to account in contract, remove archAddress from this type
-  archAddress: string; // same as account, contract expects archAddress
-  signer: SignerWithAddress;
-  bounty: BigNumber;
-  diggingFee: BigNumber;
-  storageFee: BigNumber;
-  hashedShard: string;
-  signature?: Signature;
 }


### PR DESCRIPTION
## Overview
Removes concept of the bounty from the system completely.

## TODO
The `calculateCursedBond` method is currently *just* the digging fee now, so is pointless. This method should most likely get removed in a followup PR.

The `storageFee` will be removed in the followup PR which also removed the arweave archaeologist.