### PR TITLE
Remove arweave arch

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -26,6 +26,7 @@ contract ArchaeologistFacet {
 
     event RegisterArchaeologist(
         address indexed archaeologist,
+        string peerId,
         uint256 minimumDiggingFee,
         uint256 maximumRewrapInterval,
         uint256 freeBond
@@ -33,6 +34,7 @@ contract ArchaeologistFacet {
 
     event UpdateArchaeologist(
         address indexed archaeologist,
+        string peerId,
         uint256 minimumDiggingFee,
         uint256 maximumRewrapInterval,
         uint256 freeBond
@@ -48,7 +50,14 @@ contract ArchaeologistFacet {
         uint256 withdrawnReward
     );
 
+    /// @notice Registers the archaeologist profile
+    /// @param peerId The libp2p identifier for the archaeologist
+    /// @param minimumDiggingFee The archaeologist's minimum amount to accept for a digging fee
+    /// @param maximumRewrapInterval The longest interval of time from a rewrap time the arch will accept
+    /// for a resurrection
+    /// freeBond How much bond the archaeologist wants to deposit during the register call (if any)
     function registerArchaeologist(
+        string memory peerId,
         uint256 minimumDiggingFee,
         uint256 maximumRewrapInterval,
         uint256 freeBond
@@ -60,6 +69,7 @@ contract ArchaeologistFacet {
         LibTypes.ArchaeologistProfile memory newArch =
             LibTypes.ArchaeologistProfile({
                 exists: true,
+                peerId: peerId,
                 minimumDiggingFee: minimumDiggingFee,
                 maximumRewrapInterval: maximumRewrapInterval,
                 freeBond: freeBond,
@@ -79,13 +89,21 @@ contract ArchaeologistFacet {
 
         emit RegisterArchaeologist(
             msg.sender,
+            newArch.peerId,
             newArch.minimumDiggingFee,
             newArch.maximumRewrapInterval,
             newArch.freeBond
         );
     }
 
+    /// @notice Updates the archaeologist profile
+    /// @param peerId The libp2p identifier for the archaeologist
+    /// @param minimumDiggingFee The archaeologist's minimum amount to accept for a digging fee
+    /// @param maximumRewrapInterval The longest interval of time from a rewrap time the arch will accept
+    /// for a resurrection
+    /// freeBond How much bond the archaeologist wants to deposit during the update call (if any)
     function updateArchaeologist(
+        string memory peerId,
         uint256 minimumDiggingFee,
         uint256 maximumRewrapInterval,
         uint256 freeBond
@@ -95,6 +113,7 @@ contract ArchaeologistFacet {
 
         // create a new archaeologist
         LibTypes.ArchaeologistProfile storage existingArch = s.archaeologistProfiles[msg.sender];
+        existingArch.peerId = peerId;
         existingArch.minimumDiggingFee = minimumDiggingFee;
         existingArch.maximumRewrapInterval = maximumRewrapInterval;
 
@@ -107,6 +126,7 @@ contract ArchaeologistFacet {
 
         emit UpdateArchaeologist(
             msg.sender,
+            existingArch.peerId,
             existingArch.minimumDiggingFee,
             existingArch.maximumRewrapInterval,
             existingArch.freeBond

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -43,7 +43,6 @@ library LibTypes {
     // deep" error.
     struct SelectedArchaeologistMemory {
         address archAddress;
-        uint256 storageFee;
         uint256 diggingFee;
         bytes32 hashedShard;
     }
@@ -97,10 +96,8 @@ library LibTypes {
         uint256 resurrectionTime;
         uint256 resurrectionWindow;
         string[] arweaveTxIds;
-        uint256 storageFee;
         address embalmer;
         address recipientAddress;
-        address arweaveArchaeologist;
         address[] archaeologists;
     }
 

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -67,6 +67,7 @@ library LibTypes {
     // ArchaeologistProfile is used to store archaeologist profile data
     struct ArchaeologistProfile {
         bool exists;
+        string peerId;
         uint256 minimumDiggingFee;
         uint256 maximumRewrapInterval;
         uint256 freeBond;

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -38,7 +38,7 @@ struct AppStorage {
     // double hashed and used as a constant O(1) lookup here
     mapping(bytes32 => address) doubleHashedShardArchaeologists;
     // A mapping used to store an archaeologist's data on a sarcophagus.
-    // Bounty, digging fees, storage fees, and the hashed shards of the
+    // Digging fees, storage fees, and the hashed shards of the
     // archaeologists all need to be stored per sarcophagus. This mapping of a
     // mapping stores the archaeologist's data we need per sarcophagus.
     // Example usage (to retrieve the digging fees an archaeologist may claim on some sarcophagus):

--- a/test/facets/archaeologist-facet.spec.ts
+++ b/test/facets/archaeologist-facet.spec.ts
@@ -55,13 +55,15 @@ describe("Contract: ArchaeologistFacet", () => {
       const minDiggingFee = "40";
       const maxRewrapInterval = "50";
       const freeBond = "90";
+      const peerId = "myNewPeerId";
 
       await registerArchaeologist(
         archaeologist,
         archaeologistFacet,
         minDiggingFee,
         maxRewrapInterval,
-        freeBond
+        freeBond,
+        peerId
       );
 
       const registeredArch = await viewStateFacet.getArchaeologistProfile(
@@ -70,6 +72,7 @@ describe("Contract: ArchaeologistFacet", () => {
       expect(registeredArch.minimumDiggingFee).to.equal(BigNumber.from(minDiggingFee));
       expect(registeredArch.maximumRewrapInterval).to.equal(BigNumber.from(maxRewrapInterval));
       expect(registeredArch.freeBond).to.equal(BigNumber.from(freeBond));
+      expect(registeredArch.peerId).to.equal(peerId);
     });
 
     it("adds the archaeologist address to the archaeologistProfileAddresses array", async () => {
@@ -122,6 +125,7 @@ describe("Contract: ArchaeologistFacet", () => {
       const minDiggingFee = "150";
       const maxRewrapInterval = "150";
       const freeBond = "150";
+      const peerId = "myNewPeerId";
 
       const archFreeBondBeforeUpdate = await viewStateFacet.getFreeBond(archaeologist.archAddress);
 
@@ -130,7 +134,8 @@ describe("Contract: ArchaeologistFacet", () => {
         archaeologistFacet,
         minDiggingFee,
         maxRewrapInterval,
-        freeBond
+        freeBond,
+        peerId
       );
 
       const registeredArch = await viewStateFacet.getArchaeologistProfile(
@@ -141,6 +146,7 @@ describe("Contract: ArchaeologistFacet", () => {
       expect(registeredArch.freeBond.sub(archFreeBondBeforeUpdate)).to.equal(
         BigNumber.from(freeBond)
       );
+      expect(registeredArch.peerId).to.equal(peerId);
     });
 
     it("deposits free bond to the sarcophagus contract when updating with a positive free bond value", async () => {

--- a/test/facets/gas-reports.spec.ts
+++ b/test/facets/gas-reports.spec.ts
@@ -155,7 +155,6 @@ async function _runCreateSarcoTest(arg: { shares: number; threshold: number }) {
   const {
     archaeologists,
     sarcoId,
-    arweaveSignature,
     embalmer,
     embalmerFacet,
     shards,
@@ -174,7 +173,6 @@ async function _runCreateSarcoTest(arg: { shares: number; threshold: number }) {
   return {
     sarcoId: sarcoId,
     archaeologists,
-    arweaveSignature,
     archaeologistFacet,
     embalmer,
     embalmerFacet,

--- a/test/fixtures/archaeologists-fixture.ts
+++ b/test/fixtures/archaeologists-fixture.ts
@@ -35,7 +35,6 @@ export const archeologistsFixture = (count: number) =>
           hashedShard: "",
           unencryptedShard: [],
           signer: acc,
-          storageFee: ethers.utils.parseEther("20"),
           diggingFee: ethers.utils.parseEther("10")
         });
 

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -15,14 +15,13 @@ import { spawnArchaologistsWithSignatures, TestArchaeologist } from "./spawn-arc
 const sss = require("shamirs-secret-sharing");
 
 /**
- * A fixture to set up a test that reqiures a successful initialization on a
- * transferrable sarcophagus. Deploys all contracts required for the system,
+ * A fixture to set up a test that requires a successful initialization on a
+ * transferable sarcophagus. Deploys all contracts required for the system,
  * and initializes a sarcophagus with given config and name, with archaeologists
  * created and pre-configured for it.
  *
- * Ressurection time is set to 1 week.
+ * Resurrection time is set to 1 week.
  * maxResurrectionInterval defaults to 1 week.
- * Arweave archaeologist is set to the first in the returned list of archaeologists.
  *
  * Optionally, initialising and finalising may be skipped. It's also possible to
  * indicate to return a specified number of archaeologists not bonded to the
@@ -111,7 +110,6 @@ export const createSarcoFixture = (
             hashedShard: "",
             unencryptedShard: [],
             signer: acc,
-            storageFee: ethers.utils.parseEther("20"),
             diggingFee: ethers.utils.parseEther("10")
           });
 
@@ -131,7 +129,6 @@ export const createSarcoFixture = (
         }
       }
 
-      const arweaveArchaeologist = archaeologists[0];
       const canBeTransferred = true;
 
       const resurrectionTime = (await time.latest()) + time.duration.weeks(1);
@@ -151,7 +148,6 @@ export const createSarcoFixture = (
             minShards: config.threshold,
           },
           archaeologists,
-          arweaveArchaeologist.signer.address
         );
       }
 
@@ -161,14 +157,12 @@ export const createSarcoFixture = (
 
       const arweaveTxId = "arweaveTxId";
 
-      const arweaveSignature = await sign(arweaveArchaeologist.signer, arweaveTxId, "string");
-
       // Finalize the sarcophagus (will be skipped if initialize is skipped)
       let finalizeTx: Promise<ContractTransaction> | undefined;
       if (config.skipInitialize !== true && config.skipFinalize !== true) {
         finalizeTx = embalmerFacet
           .connect(embalmer)
-          .finalizeSarcophagus(sarcoId, signatures.slice(1), arweaveSignature, arweaveTxId);
+          .finalizeSarcophagus(sarcoId, signatures, arweaveTxId);
       }
 
       if (config.dontAwaitInitTx !== true && config.dontAwaitFinalizeTx !== true) {
@@ -184,8 +178,6 @@ export const createSarcoFixture = (
         archaeologists,
         unbondedArchaeologists,
         signatures,
-        arweaveSignature,
-        arweaveArchaeologist,
         arweaveTxId,
         embalmerBalanceBefore,
         shards,

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -122,6 +122,7 @@ export const createSarcoFixture = (
           await sarcoToken.connect(acc).approve(diamond.address, ethers.constants.MaxUint256);
 
           await archaeologistFacet.connect(acc).registerArchaeologist(
+            "myFakePeerId",
             ethers.utils.parseEther("10"),
             BigNumber.from("1000"),
             ethers.utils.parseEther("5000")

--- a/test/fixtures/spawn-archaeologists.ts
+++ b/test/fixtures/spawn-archaeologists.ts
@@ -9,7 +9,6 @@ import { ArchaeologistFacet, IERC20 } from "../../typechain";
 export interface TestArchaeologist {
   archAddress: string;
   signer: SignerWithAddress;
-  storageFee: BigNumber;
   diggingFee: BigNumber;
   hashedShard: string;
   unencryptedShard: BytesLike;
@@ -49,7 +48,6 @@ export async function spawnArchaologistsWithSignatures(
       hashedShard: ethers.utils.solidityKeccak256(["bytes"], [shards[shardI]]),
       unencryptedShard: shards[shardI],
       signer: acc,
-      storageFee: BigNumber.from("20"),
       diggingFee: BigNumber.from("10")
     });
 

--- a/test/fixtures/spawn-archaeologists.ts
+++ b/test/fixtures/spawn-archaeologists.ts
@@ -59,6 +59,7 @@ export async function spawnArchaologistsWithSignatures(
 
     // Deposit 5000 tokens for each archaeologist so they're ready to be bonded
     await archaeologistFacet.connect(acc).registerArchaeologist(
+      "myFakePeerId",
       ethers.utils.parseEther("10"),
       BigNumber.from("1000"),
       ethers.utils.parseEther("5000")

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -126,15 +126,18 @@ export const registerArchaeologist = async (
   archaeologistFacet: ArchaeologistFacet,
   minDiggingFee?: string,
   minRewrapInterval?: string,
-  freeBond?: string
+  freeBond?: string,
+  peerId?: string
 ): Promise<void> => {
   freeBond = freeBond || "0";
   minDiggingFee = minDiggingFee || "100";
   minRewrapInterval = minRewrapInterval || "10000";
+  peerId = peerId || "myfakelibp2pPeerId"
 
   await archaeologistFacet
     .connect(archaeologist.signer)
     .registerArchaeologist(
+      peerId,
       BigNumber.from(minDiggingFee),
       BigNumber.from(minRewrapInterval),
       BigNumber.from(freeBond)
@@ -146,11 +149,13 @@ export const updateArchaeologist = async (
   archaeologistFacet: ArchaeologistFacet,
   minDiggingFee: string,
   minRewrapInterval: string,
-  freeBond?: string
+  freeBond?: string,
+  peerId?: string
 ): Promise<void> => {
   await archaeologistFacet
     .connect(archaeologist.signer)
     .updateArchaeologist(
+      peerId || "myfakelibp2pPeerId",
       BigNumber.from(minDiggingFee),
       BigNumber.from(minRewrapInterval),
       BigNumber.from(freeBond || 0)

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,7 +19,6 @@ export interface DiamondCut {
 
 export interface Archaeologist {
   archAddress: string;
-  storageFee: BigNumber;
   diggingFee: BigNumber;
   hashedShard: string;
 }


### PR DESCRIPTION
## Overview
Removes the storage fee and arweave archaeologist from the contracts. Updates the tests as well

## Notes
1. A few tests relating to the arweave arch were removed which may be useful as reference points when the arweave signatures are updated (see TODO below)

## TODO
All archaeologists must now provide signatures of: 
- arch address (or pub key)
- arweave tx id
- unencryptedShardHash

This will be handled in the PR that combines initialize/finalize