### PR TITLE
Add function to get arch stats

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -220,7 +220,7 @@ contract ArchaeologistFacet {
 
         // Save the successful sarcophagus against the archaeologist
         s.archaeologistSarcoSuccesses[msg.sender][sarcoId] = true;
-        s.archaeologistSuccesses[msg.sender]++;
+        s.archaeologistSuccesses[msg.sender].push(sarcoId);
 
         // Transfer the digging fee to the archaeologist's reward pool
         s.archaeologistRewards[msg.sender] += archaeologistData.diggingFee;

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -65,8 +65,8 @@ contract ArchaeologistFacet {
         LibUtils.revertIfArchProfileExists(msg.sender);
 
         // create a new archaeologist
-        LibTypes.ArchaeologistProfile memory newArch =
-            LibTypes.ArchaeologistProfile({
+        LibTypes.ArchaeologistProfile memory newArch = LibTypes
+            .ArchaeologistProfile({
                 exists: true,
                 peerId: peerId,
                 minimumDiggingFee: minimumDiggingFee,
@@ -110,7 +110,8 @@ contract ArchaeologistFacet {
         LibUtils.revertIfArchProfileDoesNotExist(msg.sender);
 
         // create a new archaeologist
-        LibTypes.ArchaeologistProfile storage existingArch = s.archaeologistProfiles[msg.sender];
+        LibTypes.ArchaeologistProfile storage existingArch = s
+            .archaeologistProfiles[msg.sender];
         existingArch.peerId = peerId;
         existingArch.minimumDiggingFee = minimumDiggingFee;
         existingArch.maximumRewrapInterval = maximumRewrapInterval;
@@ -218,7 +219,8 @@ contract ArchaeologistFacet {
         LibBonds.freeArchaeologist(sarcoId, msg.sender);
 
         // Save the successful sarcophagus against the archaeologist
-        s.archaeologistSuccesses[msg.sender][sarcoId] = true;
+        s.archaeologistSarcoSuccesses[msg.sender][sarcoId] = true;
+        s.archaeologistSuccesses[msg.sender].push(sarcoId);
 
         // Transfer the digging fee to the archaeologist's reward pool
         s.archaeologistRewards[msg.sender] += archaeologistData.diggingFee;
@@ -293,7 +295,8 @@ contract ArchaeologistFacet {
 
         // Add the new archaeologist's address to the sarcohpagusArchaeologists mapping
         newArchData.diggingFee = oldArchData.diggingFee;
-        newArchData.unencryptedShardDoubleHash = oldArchData.unencryptedShardDoubleHash;
+        newArchData.unencryptedShardDoubleHash = oldArchData
+            .unencryptedShardDoubleHash;
         newArchData.unencryptedShard = "";
 
         // Set the old archaeologist's data in the sarcophagusArchaeologists

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -220,7 +220,7 @@ contract ArchaeologistFacet {
 
         // Save the successful sarcophagus against the archaeologist
         s.archaeologistSarcoSuccesses[msg.sender][sarcoId] = true;
-        s.archaeologistSuccesses[msg.sender].push(sarcoId);
+        s.archaeologistSuccesses[msg.sender]++;
 
         // Transfer the digging fee to the archaeologist's reward pool
         s.archaeologistRewards[msg.sender] += archaeologistData.diggingFee;

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -68,7 +68,7 @@ contract ThirdPartyFacet {
                 LibBonds.decreaseCursedBond(archAddresses[i], cursedBond);
 
                 // Save the failure to unwrap against the archaeologist
-                s.archaeologistCleanups[archAddresses[i]].push(sarcoId);
+                s.archaeologistCleanups[archAddresses[i]]++;
             }
         }
 
@@ -158,7 +158,7 @@ contract ThirdPartyFacet {
                 LibBonds.decreaseCursedBond(matchingArchAddr, cursedBond);
 
                 // Save the accusal against the archaeologist
-                s.archaeologistAccusals[matchingArchAddr].push(sarcoId);
+                s.archaeologistAccusals[matchingArchAddr]++;
             } else {
                 revert LibErrors.AccuseIncorrectProof();
             }

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -68,7 +68,7 @@ contract ThirdPartyFacet {
                 LibBonds.decreaseCursedBond(archAddresses[i], cursedBond);
 
                 // Save the failure to unwrap against the archaeologist
-                s.archaeologistCleanups[archAddresses[i]]++;
+                s.archaeologistCleanups[archAddresses[i]].push(sarcoId);
             }
         }
 
@@ -158,7 +158,7 @@ contract ThirdPartyFacet {
                 LibBonds.decreaseCursedBond(matchingArchAddr, cursedBond);
 
                 // Save the accusal against the archaeologist
-                s.archaeologistAccusals[matchingArchAddr]++;
+                s.archaeologistAccusals[matchingArchAddr].push(sarcoId);
             } else {
                 revert LibErrors.AccuseIncorrectProof();
             }

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -36,11 +36,7 @@ contract ThirdPartyFacet {
         }
 
         // Make sure the sarco is cleanable
-        if (
-            block.timestamp <
-            s.gracePeriod +
-                sarco.resurrectionTime
-        ) {
+        if (block.timestamp < s.gracePeriod + sarco.resurrectionTime) {
             revert LibErrors.SarcophagusNotCleanable();
         }
 
@@ -52,7 +48,7 @@ contract ThirdPartyFacet {
         uint256 totalDiggingFee;
 
         for (uint256 i = 0; i < archAddresses.length; i++) {
-            bool didNotUnwrap = s.archaeologistSuccesses[archAddresses[i]][
+            bool didNotUnwrap = s.archaeologistSarcoSuccesses[archAddresses[i]][
                 sarcoId
             ] == false;
 
@@ -122,7 +118,10 @@ contract ThirdPartyFacet {
         }
 
         if (unencryptedShardHashes.length < sarco.minShards) {
-            revert LibErrors.AccuseNotEnoughProof(unencryptedShardHashes.length, sarco.minShards);
+            revert LibErrors.AccuseNotEnoughProof(
+                unencryptedShardHashes.length,
+                sarco.minShards
+            );
         }
 
         address[] memory accusedArchAddresses = new address[](
@@ -239,10 +238,7 @@ contract ThirdPartyFacet {
 
         // transfer the cursed half, plus digging fee to the
         // embalmer
-        s.sarcoToken.transfer(
-            sarc.embalmer,
-            totalDiggingFee + halfToEmbalmer
-        );
+        s.sarcoToken.transfer(sarc.embalmer, totalDiggingFee + halfToEmbalmer);
 
         // transfer the other half of the cursed bond to the transaction caller
         s.sarcoToken.transfer(paymentAddress, halfToSender);

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../libraries/LibTypes.sol";
+import "hardhat/console.sol";
 import {AppStorage} from "../storage/LibAppStorage.sol";
 
 contract ViewStateFacet {
@@ -30,7 +31,7 @@ contract ViewStateFacet {
     {
         LibTypes.ArchaeologistProfile[]
             memory profiles = new LibTypes.ArchaeologistProfile[](
-                s.archaeologistProfileAddresses.length
+                addresses.length
             );
 
         for (uint256 i = 0; i < addresses.length; i++) {
@@ -42,6 +43,33 @@ contract ViewStateFacet {
         }
 
         return profiles;
+    }
+
+    /// @notice Gets statistics for each archaeologist
+    /// Contains a list of sarcoIds for each category. We could simply return the counts of the
+    /// arrays but we are already storing the lists of sarcoIds so we may as well use them.
+    /// @param addresses The list of archaeologist addresses
+    /// @return The list of archaeologist statistics
+    function getArchaeologistsStatistics(address[] memory addresses)
+        external
+        view
+        returns (LibTypes.ArchaeologistStatistics[] memory)
+    {
+        LibTypes.ArchaeologistStatistics[]
+            memory statsList = new LibTypes.ArchaeologistStatistics[](
+                addresses.length
+            );
+        console.log("here");
+
+        for (uint256 i = 0; i < addresses.length; i++) {
+            statsList[i] = LibTypes.ArchaeologistStatistics(
+                s.archaeologistSuccesses[addresses[i]],
+                s.archaeologistCancels[addresses[i]],
+                s.archaeologistAccusals[addresses[i]]
+            );
+        }
+
+        return statsList;
     }
 
     /// @notice Gets the grace period an archaeologist is given to resurrect a sarcophagus after the resurrection time passes
@@ -120,7 +148,7 @@ contract ViewStateFacet {
         address archaeologist,
         bytes32 sarcoId
     ) external view returns (bool) {
-        return s.archaeologistSuccesses[archaeologist][sarcoId];
+        return s.archaeologistSarcoSuccesses[archaeologist][sarcoId];
     }
 
     /// @notice Returns the number of accusations for an archaeologist.

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -45,32 +45,6 @@ contract ViewStateFacet {
         return profiles;
     }
 
-    /// @notice Gets statistics for each archaeologist
-    /// Contains a list of sarcoIds for each category. We could simply return the counts of the
-    /// arrays but we are already storing the lists of sarcoIds so we may as well use them.
-    /// @param addresses The list of archaeologist addresses
-    /// @return The list of archaeologist statistics
-    function getArchaeologistsStatistics(address[] memory addresses)
-        external
-        view
-        returns (LibTypes.ArchaeologistStatistics[] memory)
-    {
-        LibTypes.ArchaeologistStatistics[]
-            memory statsList = new LibTypes.ArchaeologistStatistics[](
-                addresses.length
-            );
-
-        for (uint256 i = 0; i < addresses.length; i++) {
-            statsList[i] = LibTypes.ArchaeologistStatistics(
-                s.archaeologistSuccesses[addresses[i]],
-                s.archaeologistAccusals[addresses[i]],
-                s.archaeologistCleanups[addresses[i]]
-            );
-        }
-
-        return statsList;
-    }
-
     /// @notice Gets the grace period an archaeologist is given to resurrect a sarcophagus after the resurrection time passes
     /// @return The resurrection grace period
     function getGracePeriod() external view returns (uint256) {
@@ -143,6 +117,9 @@ contract ViewStateFacet {
         return s.archaeologistProfiles[archaeologist].cursedBond;
     }
 
+    /// @notice Returns whether an archaeologist completed an unwrap for a sarcophagus
+    /// @param archaeologist The address of the archaeologist
+    /// @param sarcoId the sarcophagus to check if unwrapping occured
     function getArchaeologistSuccessOnSarcophagus(
         address archaeologist,
         bytes32 sarcoId
@@ -150,26 +127,113 @@ contract ViewStateFacet {
         return s.archaeologistSarcoSuccesses[archaeologist][sarcoId];
     }
 
-    /// @notice Returns the number of accusations for an archaeologist.
-    /// @param archaeologist The address of the archaeologist whose accusations
-    /// are being returned
-    function getArchaeologistAccusals(address archaeologist)
+    /// @notice Returns the number of successful unwraps for an archaeologist.
+    /// @param archaeologist The address of the archaeologist whose success
+    //  count is being returned
+    function getArchaeologistSuccessesCount(address archaeologist)
         external
         view
         returns (uint256)
     {
-        return s.archaeologistAccusals[archaeologist];
+        return s.archaeologistSuccesses[archaeologist].length;
+    }
+
+    /// @notice Returns the sarcophagus unique identifier for a given
+    /// archaeologist and index of the successfully unwrapped sarcophagi
+    /// @param archaeologist The address of an archaeologist
+    /// @param index The index of the archaeologist's unwrapped sarcophagi
+    /// @return the identifier associated with the index of the archaeologist's
+    /// unwrapped sarcophagi
+    function archaeologistSuccessesIdentifier(
+        address archaeologist,
+        uint256 index
+    )
+        external
+        view
+        returns (bytes32)
+    {
+        return s.archaeologistSuccesses[archaeologist][index];
+    }
+
+    /// @notice Returns the number of accusations for an archaeologist.
+    /// @param archaeologist The address of the archaeologist whose accusations
+    /// count is being returned
+    function getArchaeologistAccusalsCount(address archaeologist)
+        external
+        view
+        returns (uint256)
+    {
+        return s.archaeologistAccusals[archaeologist].length;
+    }
+
+    /// @notice Returns the sarcophagus unique identifier for a given
+    /// archaeologist and index of the accused sarcophagi
+    /// @param archaeologist The address of an archaeologist
+    /// @param index The index of the archaeologist's accused sarcophagi
+    /// @return the identifier associated with the index of the archaeologist's
+    /// accused sarcophagi
+    function archaeologistAccusalsIdentifier(
+        address archaeologist,
+        uint256 index
+    )
+        external
+        view
+        returns (bytes32)
+    {
+        return s.archaeologistAccusals[archaeologist][index];
     }
 
     /// @notice Returns the number of cleanups for an archaeologist.
     /// @param archaeologist The address of the archaeologist whose cleanups
-    /// are being returned
-    function getArchaeologistCleanups(address archaeologist)
+    /// count is being returned
+    function getArchaeologistCleanupsCount(address archaeologist)
         external
         view
         returns (uint256)
     {
-        return s.archaeologistCleanups[archaeologist];
+        return s.archaeologistCleanups[archaeologist].length;
+    }
+
+    /// @notice Returns the sarcophagus unique identifier for a given
+    /// archaeologist and index of the leaned-up sarcophagi
+    /// @param archaeologist The address of an archaeologist
+    /// @param index The index of the archaeologist's leaned-up sarcophagi
+    /// @return the identifier associated with the index of the archaeologist's
+    /// cleaned-up sarcophagi
+    function archaeologistCleanupsIdentifier(
+        address archaeologist,
+        uint256 index
+    )
+        external
+        view
+        returns (bytes32)
+    {
+        return s.archaeologistCleanups[archaeologist][index];
+    }
+
+    /// @notice Gets all reputation statistics for each archaeologist
+    /// Contains a list of counts for each category.
+    /// @param addresses The list of archaeologist addresses
+    /// @return The list of archaeologist statistics
+    function getArchaeologistsStatistics(address[] memory addresses)
+        external
+        view
+        returns (LibTypes.ArchaeologistStatistics[] memory)
+    {
+        LibTypes.ArchaeologistStatistics[]
+        memory statsList = new LibTypes.ArchaeologistStatistics[](
+            addresses.length
+        );
+
+        for (uint256 i = 0; i < addresses.length; i++) {
+            statsList[i] = LibTypes.ArchaeologistStatistics(
+                this.getArchaeologistSuccessesCount(addresses[i]),
+                this.getArchaeologistAccusalsCount(addresses[i]),
+                this.getArchaeologistCleanupsCount(addresses[i])
+            );
+        }
+
+        return statsList;
     }
 
     /// @notice Returns a sarcophagus.

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -59,13 +59,12 @@ contract ViewStateFacet {
             memory statsList = new LibTypes.ArchaeologistStatistics[](
                 addresses.length
             );
-        console.log("here");
 
         for (uint256 i = 0; i < addresses.length; i++) {
             statsList[i] = LibTypes.ArchaeologistStatistics(
                 s.archaeologistSuccesses[addresses[i]],
-                s.archaeologistCancels[addresses[i]],
-                s.archaeologistAccusals[addresses[i]]
+                s.archaeologistAccusals[addresses[i]],
+                s.archaeologistCleanups[addresses[i]]
             );
         }
 
@@ -157,7 +156,7 @@ contract ViewStateFacet {
     function getArchaeologistAccusals(address archaeologist)
         external
         view
-        returns (bytes32[] memory)
+        returns (uint256)
     {
         return s.archaeologistAccusals[archaeologist];
     }
@@ -168,7 +167,7 @@ contract ViewStateFacet {
     function getArchaeologistCleanups(address archaeologist)
         external
         view
-        returns (bytes32[] memory)
+        returns (uint256)
     {
         return s.archaeologistCleanups[archaeologist];
     }

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -110,4 +110,13 @@ library LibTypes {
         uint256 resurrectionTime;
         uint256 diggingFeesPaid;
     }
+
+    // Only used in the ViewStateFacet to return statistics data.
+    // Contains a list of sarcoIds for each category. We could simply return the counts of the
+    // arrays but we are already storing the lists of sarcoIds so we may as well use them.
+    struct ArchaeologistStatistics {
+        bytes32[] successes;
+        bytes32[] cancels;
+        bytes32[] accusals;
+    }
 }

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -115,8 +115,8 @@ library LibTypes {
     // Contains a list of sarcoIds for each category. We could simply return the counts of the
     // arrays but we are already storing the lists of sarcoIds so we may as well use them.
     struct ArchaeologistStatistics {
-        bytes32[] successes;
-        bytes32[] cancels;
-        bytes32[] accusals;
+        uint256 successes;
+        uint256 accusals;
+        uint256 cleanups;
     }
 }

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -21,11 +21,16 @@ struct AppStorage {
     // archaeologist profiles
     address[] archaeologistProfileAddresses;
     mapping(address => LibTypes.ArchaeologistProfile) archaeologistProfiles;
-    // archaeologist stats
+
+    // archaeologistSarcoSuccesses is needed by the clean function
+    // to lookup whether an archaeologist has completed an unwrapping
     mapping(address => mapping(bytes32 => bool)) archaeologistSarcoSuccesses;
-    mapping(address => uint256) archaeologistSuccesses;
-    mapping(address => uint256) archaeologistAccusals;
-    mapping(address => uint256) archaeologistCleanups;
+
+    // Archaeologist reputation statistics
+    mapping(address => bytes32[]) archaeologistSuccesses;
+    mapping(address => bytes32[]) archaeologistAccusals;
+    mapping(address => bytes32[]) archaeologistCleanups;
+
     // Track how much archaeologists have made. To be credited and debited
     // as archaeologists fulfill their duties and withdraw their rewards
     mapping(address => uint256) archaeologistRewards;

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -23,10 +23,9 @@ struct AppStorage {
     mapping(address => LibTypes.ArchaeologistProfile) archaeologistProfiles;
     // archaeologist stats
     mapping(address => mapping(bytes32 => bool)) archaeologistSarcoSuccesses;
-    mapping(address => bytes32[]) archaeologistSuccesses;
-    mapping(address => bytes32[]) archaeologistCancels;
-    mapping(address => bytes32[]) archaeologistAccusals;
-    mapping(address => bytes32[]) archaeologistCleanups;
+    mapping(address => uint256) archaeologistSuccesses;
+    mapping(address => uint256) archaeologistAccusals;
+    mapping(address => uint256) archaeologistCleanups;
     // Track how much archaeologists have made. To be credited and debited
     // as archaeologists fulfill their duties and withdraw their rewards
     mapping(address => uint256) archaeologistRewards;

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -22,7 +22,8 @@ struct AppStorage {
     address[] archaeologistProfileAddresses;
     mapping(address => LibTypes.ArchaeologistProfile) archaeologistProfiles;
     // archaeologist stats
-    mapping(address => mapping(bytes32 => bool)) archaeologistSuccesses;
+    mapping(address => mapping(bytes32 => bool)) archaeologistSarcoSuccesses;
+    mapping(address => bytes32[]) archaeologistSuccesses;
     mapping(address => bytes32[]) archaeologistCancels;
     mapping(address => bytes32[]) archaeologistAccusals;
     mapping(address => bytes32[]) archaeologistCleanups;

--- a/test/facets/third-party-facet.spec.ts
+++ b/test/facets/third-party-facet.spec.ts
@@ -171,7 +171,7 @@ describe("Contract: ThirdPartyFacet", () => {
         // Get the clean up count of each archaeologist before cleaning
         const cleanupsBefore: BigNumber[] = [];
         for (const arch of archaeologists) {
-          cleanupsBefore.push(await viewStateFacet.getArchaeologistCleanups(arch.archAddress));
+          cleanupsBefore.push(await viewStateFacet.getArchaeologistCleanupsCount(arch.archAddress));
         }
 
         // Clean the sarcophagus
@@ -180,7 +180,7 @@ describe("Contract: ThirdPartyFacet", () => {
         // Get the clean up count of each archaeologist after cleaning
         const cleanupsAfter: BigNumber[] = [];
         for (const arch of archaeologists) {
-          cleanupsAfter.push(await viewStateFacet.getArchaeologistCleanups(arch.archAddress));
+          cleanupsAfter.push(await viewStateFacet.getArchaeologistCleanupsCount(arch.archAddress));
         }
 
         // For each archaeologist, if the arch was accused expect the count to have increased by 1
@@ -434,7 +434,7 @@ describe("Contract: ThirdPartyFacet", () => {
         // Get each archaeologist's accusal count before accuse
         const accusalsBefore = [];
         for (const arch of accusedArchs) {
-          accusalsBefore.push(await viewStateFacet.getArchaeologistAccusals(arch.archAddress));
+          accusalsBefore.push(await viewStateFacet.getArchaeologistAccusalsCount(arch.archAddress));
         }
 
         // Accuse archaeologists
@@ -447,7 +447,7 @@ describe("Contract: ThirdPartyFacet", () => {
         // Get each archaeologist's accusal count after accuse
         const accusalsAfter = [];
         for (const arch of accusedArchs) {
-          accusalsAfter.push(await viewStateFacet.getArchaeologistAccusals(arch.archAddress));
+          accusalsAfter.push(await viewStateFacet.getArchaeologistAccusalsCount(arch.archAddress));
         }
 
         // For each accused archaeologist, check that their accusal count has increased by 1
@@ -455,7 +455,7 @@ describe("Contract: ThirdPartyFacet", () => {
           expect(accusalsAfter[i].eq(accusalsBefore[i].add(1))).to.be.true;
         }
 
-        const goodArchAccusals = await viewStateFacet.getArchaeologistAccusals(
+        const goodArchAccusals = await viewStateFacet.getArchaeologistAccusalsCount(
           archaeologists[0].archAddress
         );
 


### PR DESCRIPTION
Adds a function to get archaeologist reputation stats.

### Notes
- Added `archaeologistSuccesses` that keeps a list of sarcoIds like the cancels and accusals. Otherwise there is no easy way to get a list of successes.
- Added an aggregate stats view state function to return all stats in a single function call. This will be the function the front-end uses to grab the stats.
- Updated the view state facet stats functions to return the length of the mappings + added index lookup functions so that sarcoIds for each arch stat category can be queried. These individual stats methods (index / lengths) are not used by the front end currently, but think they hold enough utility/value to add.