### PR TITLE
65 max rewrap interval

### DIFF
--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -41,23 +41,24 @@ contract EmbalmerFacet {
 
     /// @notice Embalmer creates the sarcophagus.
     ///
-    /// The purpose of initializeSarcophagus is to:
+    /// The purpose of createSarcophagus is to:
     ///   - Lock up payment for the selected archaeologists (digging fees)
     ///   - Store the arweave TX IDs pertaining to the encrypted file payload
     ///   -    and the encrypted shards
-    ///   - Verify the selected archaeologists have signed off on their
-    ///   -    unencrypted double hash and the arweave TX ID pertaining
-    ///   -    to the encrypted hashes
+    ///   - Verify the selected archaeologists have signed off on the
+    ///         double hash of their key share,
+    ///         arweave tx id storing key shares,
+    ///         and maximumRewrapInterval to be used for lifetime of the sarcophagus
     ///   - Store the selected archaeologists' addresses, digging fees and
-    ///   -    unencrypted double hashes
+    ///   -     unencrypted double hashes
     ///   - Curse each participating archaeologist
     ///   - Create the sarcophagus object
-    ///
     ///
     /// @param sarcoId the identifier of the sarcophagus
     /// @param sarcophagus an object that contains the sarcophagus data
     /// @param selectedArchaeologists the archaeologists the embalmer has selected to curse
-    /// @param arweaveTxIds the tx ids where arweave data is stored
+    /// @param arweaveTxIds ordered pair of arweave tx ids: [tx storing sarcophagus payload,
+    ///         tx storing the archaeologists' encrypted key shares]
     /// @return The index of the new sarcophagus
     function createSarcophagus(
         bytes32 sarcoId,
@@ -80,6 +81,11 @@ contract EmbalmerFacet {
             );
         }
 
+        // Confirm that resurrection or rewrap will occur before the maximumRewrapInterval elapses
+        if (sarcophagus.resurrectionTime > block.timestamp + sarcophagus.maximumRewrapInterval) {
+            revert LibErrors.ResurrectionTimeTooFarInFuture(sarcophagus.resurrectionTime, sarcophagus.maximumRewrapInterval);
+        }
+
         // Validate exactly 2 arweave TX IDs have been provided
         // TODO: See if we can verify exact byte length of arweave TXs
         if (arweaveTxIds.length != 2 || bytes(arweaveTxIds[0]).length == 0 || bytes(arweaveTxIds[1]).length == 0) {
@@ -96,7 +102,8 @@ contract EmbalmerFacet {
             revert LibErrors.MinShardsZero();
         }
 
-        // Confirm that minShards is less than the number of archaeologists
+        // Confirm that minShards is less than or equal to the number of archaeologists
+        // (k <= n in a shamir secret sharing scheme)
         if (sarcophagus.minShards > selectedArchaeologists.length) {
             revert LibErrors.MinShardsGreaterThanArchaeologists(
                 sarcophagus.minShards
@@ -126,15 +133,15 @@ contract EmbalmerFacet {
 
             // Validate archaeologist profile value requirements are met
             LibUtils.revertIfDiggingFeeTooLow(arch.diggingFee, arch.archAddress);
-            LibUtils.revertIfResurrectionTimeTooFarInFuture(sarcophagus.resurrectionTime, arch.archAddress);
 
             totalDiggingFees += arch.diggingFee;
 
-            // Validate the archaeologist has signed off on their shard data:
-            // hashed shard, arweaveTxId[1] (encrypted shard on arweave)
+            // Validate the archaeologist has signed off on the sarcophagus parameters: double hashed key share,
+            // arweaveTxId[1] (tx storing share on arweave), maximumRewrapInterval for sarcophagus
             LibUtils.verifyArchaeologistSignature(
                 arch.unencryptedShardDoubleHash,
                 arweaveTxIds[1],
+                sarcophagus.maximumRewrapInterval,
                 arch.v,
                 arch.r,
                 arch.s,
@@ -150,7 +157,7 @@ contract EmbalmerFacet {
                     curseTokenId: 0
                 });
 
-            // Map the double-hashed shared to this archaeologist's address for easier referencing on accuse
+            // Map the double-hashed share to this archaeologist's address for easier referencing on accuse
             s.doubleHashedShardArchaeologists[arch.unencryptedShardDoubleHash] = arch
                 .archAddress;
 
@@ -177,7 +184,7 @@ contract EmbalmerFacet {
             canBeTransferred: sarcophagus.canBeTransferred,
             minShards: sarcophagus.minShards,
             resurrectionTime: sarcophagus.resurrectionTime,
-            gracePeriod: s.gracePeriod,
+            maximumRewrapInterval: sarcophagus.maximumRewrapInterval,
             arweaveTxIds: arweaveTxIds,
             embalmer: msg.sender,
             recipientAddress: sarcophagus.recipient,
@@ -240,7 +247,7 @@ contract EmbalmerFacet {
             );
         }
 
-        // Confirm that the current resurrection time is in the future, and thus rewrappable
+        // Confirm current resurrection time is in future (sarcophagus is rewrappable)
         if (s.sarcophagi[sarcoId].resurrectionTime <= block.timestamp) {
             revert LibErrors.SarcophagusIsUnwrappable();
         }
@@ -248,6 +255,12 @@ contract EmbalmerFacet {
         // Confirm that the new resurrection time is in the future
         if (resurrectionTime <= block.timestamp) {
             revert LibErrors.NewResurrectionTimeInPast(resurrectionTime);
+        }
+
+
+        // Confirm that the new resurrection time doesn't exceed the sarcophagus's maximumRewrapInterval
+        if (resurrectionTime > block.timestamp + s.sarcophagi[sarcoId].maximumRewrapInterval) {
+            revert LibErrors.NewResurrectionTimeTooLarge(resurrectionTime);
         }
 
         // For each archaeologist on the sarcophagus, transfer their digging fee allocations to them
@@ -282,7 +295,7 @@ contract EmbalmerFacet {
         // Add the protocol fee to the total protocol fees in storage
         s.totalProtocolFees += protocolFees;
 
-        // Set resurrection time to infinity
+        // Update the resurrectionTime on the sarcophagus to the supplied value
         s.sarcophagi[sarcoId].resurrectionTime = resurrectionTime;
 
         // Transfer the new digging fees from the embalmer to the sarcophagus contract.

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -43,7 +43,7 @@ library LibErrors {
 
     error ResurrectionTimeInPast(uint256 resurrectionTime);
 
-    error ResurrectionTimeTooFarInFuture(uint256 resurrectionTime, address archaeologist);
+    error ResurrectionTimeTooFarInFuture(uint256 resurrectionTime, uint256 sarcophagusMaximumRewrapInterval);
 
     error SarcophagusAlreadyExists(bytes32 sarcoId);
 

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -81,6 +81,7 @@ library LibTypes {
         string name;
         address recipient;
         uint256 resurrectionTime;
+        uint256 maximumRewrapInterval;
         bool canBeTransferred;
         uint8 minShards;
     }
@@ -97,7 +98,7 @@ library LibTypes {
         bool canBeTransferred;
         uint8 minShards;
         uint256 resurrectionTime;
-        uint256 gracePeriod;
+        uint256 maximumRewrapInterval;
         string[] arweaveTxIds;
         address embalmer;
         address recipientAddress;

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -49,6 +49,7 @@ library LibUtils {
      *
      * @param unencryptedShardDoubleHash the double hash of the unencrypted shard
      * @param arweaveTxId the arweave TX ID that contains the archs encrypted shard
+     * @param maximumRewrapInterval that the archaeologist has agreed to for the sarcophagus
      * @param v signature element
      * @param r signature element
      * @param s signature element
@@ -57,6 +58,7 @@ library LibUtils {
     function verifyArchaeologistSignature(
         bytes32 unencryptedShardDoubleHash,
         string memory arweaveTxId,
+        uint256 agreedMaximumRewrapInterval,
         uint8 v,
         bytes32 r,
         bytes32 s,
@@ -66,7 +68,7 @@ library LibUtils {
         bytes32 messageHash = keccak256(
             abi.encodePacked(
                 "\x19Ethereum Signed Message:\n32",
-                keccak256(abi.encode(unencryptedShardDoubleHash, arweaveTxId))
+                keccak256(abi.encode(arweaveTxId, unencryptedShardDoubleHash, agreedMaximumRewrapInterval))
             )
         );
 
@@ -163,20 +165,6 @@ library LibUtils {
                 .unencryptedShardDoubleHash != 0;
     }
 
-    function revertIfArchProfileIs(bool existing, address archaeologist)
-        internal
-        view
-    {
-        AppStorage storage s = LibAppStorage.getAppStorage();
-
-        if (existing ? s.archaeologistProfiles[archaeologist].exists : !s.archaeologistProfiles[archaeologist].exists) {
-            revert LibErrors.ArchaeologistProfileExistsShouldBe(
-                !existing,
-                archaeologist
-            );
-        }
-    }
-
     /// @notice Checks if an archaeologist profile exists and
     /// reverts if so
     ///
@@ -185,7 +173,14 @@ library LibUtils {
         internal
         view
     {
-        revertIfArchProfileIs(true, archaeologist);
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        if (s.archaeologistProfiles[archaeologist].exists) {
+            revert LibErrors.ArchaeologistProfileExistsShouldBe(
+                false,
+                archaeologist
+            );
+        }
     }
 
     /// @notice Checks if an archaeologist profile doesn't exist and
@@ -196,7 +191,14 @@ library LibUtils {
         internal
         view
     {
-        revertIfArchProfileIs(false, archaeologist);
+        AppStorage storage s = LibAppStorage.getAppStorage();
+
+        if (!s.archaeologistProfiles[archaeologist].exists) {
+            revert LibErrors.ArchaeologistProfileExistsShouldBe(
+                true,
+                archaeologist
+            );
+        }
     }
 
     /// @notice Checks if digging fee the embalmer has supplied for
@@ -213,23 +215,6 @@ library LibUtils {
 
         if (diggingFee < s.archaeologistProfiles[archaeologist].minimumDiggingFee) {
             revert LibErrors.DiggingFeeTooLow(diggingFee, archaeologist);
-        }
-    }
-
-    /// @notice Checks if the resurrection time supplied for the sarcophagus
-    /// is within the window that an archaeologist will accept
-    ///
-    /// @param resurrectionTime the resurrectionTime supplied for the sarcophagus
-    /// @param archaeologist the archaeologist to check the max rewrap interval of
-    function revertIfResurrectionTimeTooFarInFuture(uint256 resurrectionTime, address archaeologist)
-        internal
-        view
-    {
-        AppStorage storage s = LibAppStorage.getAppStorage();
-        uint256 maxResurrectionTime = block.timestamp + s.archaeologistProfiles[archaeologist].maximumRewrapInterval;
-
-        if (resurrectionTime > maxResurrectionTime) {
-            revert LibErrors.ResurrectionTimeTooFarInFuture(resurrectionTime, archaeologist);
         }
     }
 

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -49,7 +49,7 @@ library LibUtils {
      *
      * @param unencryptedShardDoubleHash the double hash of the unencrypted shard
      * @param arweaveTxId the arweave TX ID that contains the archs encrypted shard
-     * @param maximumRewrapInterval that the archaeologist has agreed to for the sarcophagus
+     * @param agreedMaximumRewrapInterval that the archaeologist has agreed to for the sarcophagus
      * @param v signature element
      * @param r signature element
      * @param s signature element

--- a/test/fixtures/create-sarco-fixture.ts
+++ b/test/fixtures/create-sarco-fixture.ts
@@ -7,9 +7,8 @@ import {
   EmbalmerFacet,
   IERC20,
   ThirdPartyFacet,
-  ViewStateFacet
+  ViewStateFacet,
 } from "../../typechain";
-import { sign } from "../utils/helpers";
 import time from "../utils/time";
 import { spawnArchaologistsWithSignatures, TestArchaeologist } from "./spawn-archaeologists";
 
@@ -153,6 +152,7 @@ export const createSarcoFixture = (
             name: sarcoName,
             recipient: recipient.address,
             resurrectionTime,
+            maximumRewrapInterval: maxRewrapInterval,
             canBeTransferred: true,
             minShards: config.threshold,
           },
@@ -180,6 +180,7 @@ export const createSarcoFixture = (
         createTx,
         resurrectionTime,
         diamond,
+        maximumRewrapInterval: maxRewrapInterval,
         archMinDiggingFee: config.archMinDiggingFee,
         sarcoToken: sarcoToken as IERC20,
         curses: curses as CursesMock,
@@ -187,7 +188,7 @@ export const createSarcoFixture = (
         archaeologistFacet: archaeologistFacet as ArchaeologistFacet,
         thirdPartyFacet: thirdPartyFacet as ThirdPartyFacet,
         viewStateFacet: viewStateFacet as ViewStateFacet,
-        adminFacet: adminFacet as AdminFacet
+        adminFacet: adminFacet as AdminFacet,
       };
     }
   )();

--- a/test/fixtures/spawn-archaeologists.ts
+++ b/test/fixtures/spawn-archaeologists.ts
@@ -47,6 +47,7 @@ export async function spawnArchaologistsWithSignatures(
   sarcoToken: IERC20,
   diamondAddress: string,
   maxRewrapInterval: number,
+
   archMinDiggingFee: BigNumber = BigNumber.from("10")
 ): Promise<[TestArchaeologist[], SignatureWithAccount[]]> {
   const unnamedAccounts = await getUnnamedAccounts();
@@ -62,7 +63,9 @@ export async function spawnArchaologistsWithSignatures(
   ) {
     const shardDoubleHash = doubleHashFromShard(shards[shardI]);
     const acc = await ethers.getSigner(unnamedAccounts[accountI]);
-    const signature = await sign(acc, [shardDoubleHash, arweaveTxId], ["bytes32", "string"]);
+    const signature = await sign(acc,
+      [arweaveTxId, shardDoubleHash, maxRewrapInterval.toString()],
+      ["string", "bytes32", "uint256"]);
 
     archs.push({
       archAddress: acc.address,


### PR DESCRIPTION
https://github.com/sarcophagus-org/sarcophagus-v2-contracts/issues/65
- Implements a per sarcophagus maximum resurrection time that will persist for the lifetime of the sarcophagus
- Contracts now require a maximum resurrection time to be signed by each archeologist as part of their curse agreement handshake. Expected format of data to be signed: `[arweaveTxId, unencryptedShardDoubleHash, agreedMaximumRewrapInterval]`
- removes `gracePeriod` from the sarcophagus struct, the application should rely on the system value in `AppStorage` which can be retrieved through the ViewStateFacet