### PR TITLE
Add failures to arch stats

### DIFF
--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -207,7 +207,7 @@ contract ViewStateFacet {
             uint256 failures = 0;
 
             // Get arch sarco ids
-            bytes32[] memory sarcoIds = this.getArchaeologistSarcophagi(addresses[i]);
+            bytes32[] storage sarcoIds = s.archaeologistSarcophagi[addresses[i]];
 
             // For each sarco id, if the sarco id is not included in successes and resurrection time
             // has passed, it's a failure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sarcophagus-org/sarcophagus-v2-contracts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "engines": {
     "node": ">=16.15.0"
   },


### PR DESCRIPTION
Adds failures to the arch stats in the view state function `getArchaeologistsStatistics`.

Looking at this further, the only way to avoid additional logic in the view state function is to make hundreds of RPC calls from the web app. 
1. First we would need to look up each arch's sarcophagi, an RPC call per arch
2. Second, we would need to make an RPC call per sarcophagus to check it's resurrection time to see if it has failed.

This would be an RPC call for each sarco on each arch, which for my local tests was already reaching the hundreds.

Having this logic in `getArchaeologistsStatistics` requires only 1 RPC call at the cost of adding a nested loop to the function.