### PR TITLE
Digging fees per second update

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -10,7 +10,6 @@ import {LibErrors} from "../libraries/LibErrors.sol";
 import {LibBonds} from "../libraries/LibBonds.sol";
 
 contract ArchaeologistFacet {
-
     /// @notice Emitted when an archaeologist successfully publishes their private key for a sarcophagus
     /// @param sarcoId ID of sarcophagus archaeologist has published the private key on
     /// @param privateKey private key that has been published
@@ -69,13 +68,13 @@ contract ArchaeologistFacet {
 
     /// @notice Registers the archaeologist profile
     /// @param peerId The libp2p identifier for the archaeologist
-    /// @param minimumDiggingFee The archaeologist's minimum amount to accept for a digging fee
+    /// @param minimumDiggingFeePerSecond The archaeologist's minimum amount to earn per second for being cursed
     /// @param maximumRewrapInterval The longest interval of time from a rewrap time the arch will accept
     /// for a resurrection
     /// @param freeBond How much bond the archaeologist wants to deposit during the register call (if any)
     function registerArchaeologist(
         string memory peerId,
-        uint256 minimumDiggingFee,
+        uint256 minimumDiggingFeePerSecond,
         uint256 maximumRewrapInterval,
         uint256 freeBond
     ) external {
@@ -87,7 +86,7 @@ contract ArchaeologistFacet {
         LibTypes.ArchaeologistProfile memory newArch = LibTypes.ArchaeologistProfile({
             exists: true,
             peerId: peerId,
-            minimumDiggingFee: minimumDiggingFee,
+            minimumDiggingFeePerSecond: minimumDiggingFeePerSecond,
             maximumRewrapInterval: maximumRewrapInterval,
             freeBond: freeBond,
             cursedBond: 0
@@ -106,7 +105,7 @@ contract ArchaeologistFacet {
         emit RegisterArchaeologist(
             msg.sender,
             newArch.peerId,
-            newArch.minimumDiggingFee,
+            newArch.minimumDiggingFeePerSecond,
             newArch.maximumRewrapInterval,
             newArch.freeBond
         );
@@ -114,13 +113,13 @@ contract ArchaeologistFacet {
 
     /// @notice Updates the archaeologist profile
     /// @param peerId The libp2p identifier for the archaeologist
-    /// @param minimumDiggingFee The archaeologist's minimum amount to accept for a digging fee
+    /// @param minimumDiggingFeePerSecond The archaeologist's minimum amount to earn per second for being cursed
     /// @param maximumRewrapInterval The longest interval of time from a rewrap time the arch will accept
     /// for a resurrection
     /// freeBond How much bond the archaeologist wants to deposit during the update call (if any)
     function updateArchaeologist(
         string memory peerId,
-        uint256 minimumDiggingFee,
+        uint256 minimumDiggingFeePerSecond,
         uint256 maximumRewrapInterval,
         uint256 freeBond
     ) external {
@@ -128,10 +127,9 @@ contract ArchaeologistFacet {
         // verify that the archaeologist exists
         LibUtils.revertIfArchProfileDoesNotExist(msg.sender);
 
-        // create a new archaeologist
         LibTypes.ArchaeologistProfile storage existingArch = s.archaeologistProfiles[msg.sender];
         existingArch.peerId = peerId;
-        existingArch.minimumDiggingFee = minimumDiggingFee;
+        existingArch.minimumDiggingFeePerSecond = minimumDiggingFeePerSecond;
         existingArch.maximumRewrapInterval = maximumRewrapInterval;
 
         // transfer SARCO tokens from the archaeologist to this contract, to be
@@ -144,7 +142,7 @@ contract ArchaeologistFacet {
         emit UpdateArchaeologist(
             msg.sender,
             existingArch.peerId,
-            existingArch.minimumDiggingFee,
+            existingArch.minimumDiggingFeePerSecond,
             existingArch.maximumRewrapInterval,
             existingArch.freeBond
         );
@@ -260,7 +258,6 @@ contract ArchaeologistFacet {
 
         // Free archaeologist locked bond and transfer digging fees
         LibBonds.freeArchaeologist(sarcoId, msg.sender);
-        s.archaeologistRewards[msg.sender] += cursedArchaeologist.diggingFee;
 
         // Save the successful sarcophagus against the archaeologist
         s.archaeologistSuccesses[msg.sender].push(sarcoId);

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -8,7 +8,6 @@ import "../storage/LibAppStorage.sol";
 import {LibErrors} from "../libraries/LibErrors.sol";
 import {LibBonds} from "../libraries/LibBonds.sol";
 import {LibUtils} from "../libraries/LibUtils.sol";
-import "hardhat/console.sol";
 
 contract EmbalmerFacet {
     /// @notice Emitted when a sarcophagus is created
@@ -240,7 +239,8 @@ contract EmbalmerFacet {
             // Curse the archaeologist on this sarcophagus
             uint256 diggingFeesDue = LibBonds.curseArchaeologist(
                 sarcoId,
-                selectedArchaeologists[i]
+                selectedArchaeologists[i],
+                i
             );
 
             totalDiggingFees += diggingFeesDue;

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -391,9 +391,6 @@ contract EmbalmerFacet {
             revert ResurrectionTimeInPast(block.timestamp, sarcophagus.resurrectionTime);
         }
 
-        // Set resurrection time to infinity
-        sarcophagus.resurrectionTime = 2 ** 256 - 1;
-
         // for each archaeologist on the sarcophagus, unlock bond and pay digging fees
         address[] storage archaeologistAddresses = sarcophagus.cursedArchaeologistAddresses;
         for (uint256 i = 0; i < archaeologistAddresses.length; i++) {
@@ -405,6 +402,10 @@ contract EmbalmerFacet {
                 LibBonds.freeArchaeologist(sarcoId, archaeologistAddresses[i]);
             }
         }
+
+        // TODO: Evaluate security cost of this setter being after calls to `freeArchaeologist` which unlocks bond and rewards archaeologists
+        // Set resurrection time to infinity
+        sarcophagus.resurrectionTime = 2 ** 256 - 1;
 
         emit BurySarcophagus(sarcoId);
     }

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -75,14 +75,14 @@ contract ThirdPartyFacet {
         AppStorage storage s = LibAppStorage.getAppStorage();
         LibTypes.Sarcophagus storage sarcophagus = s.sarcophagi[sarcoId];
 
-        // Confirm tx sender is embalmer or admin
-        if (msg.sender != sarcophagus.embalmerAddress && msg.sender != LibDiamond.contractOwner()) {
-            revert SenderNotEmbalmerOrAdmin(msg.sender);
-        }
-
         // Confirm the sarcophagus exists
         if (sarcophagus.resurrectionTime == 0) {
             revert LibErrors.SarcophagusDoesNotExist(sarcoId);
+        }
+
+        // Confirm tx sender is embalmer or admin
+        if (msg.sender != sarcophagus.embalmerAddress && msg.sender != LibDiamond.contractOwner()) {
+            revert SenderNotEmbalmerOrAdmin(msg.sender);
         }
 
         // Confirm the sarcophagus has not been compromised

--- a/contracts/facets/ThirdPartyFacet.sol
+++ b/contracts/facets/ThirdPartyFacet.sol
@@ -144,7 +144,7 @@ contract ThirdPartyFacet {
                 totalDiggingFeesAndLockedBonds += diggingFeesDue * 2;
 
                 // slash the archaeologist's locked bond for the sarcophagus
-                LibBonds.slashArchaeologistLockedBond(
+                LibBonds.decreaseArchaeologistLockedBond(
                     sarcophagus.cursedArchaeologistAddresses[i],
                     diggingFeesDue
                 );
@@ -262,7 +262,7 @@ contract ThirdPartyFacet {
 
             totalDiggingFees += diggingFeesDue;
 
-            LibBonds.slashArchaeologistLockedBond(accusedArchaeologistAddress, diggingFeesDue);
+            LibBonds.decreaseArchaeologistLockedBond(accusedArchaeologistAddress, diggingFeesDue);
 
             // Save this accusal against the archaeologist
             s.archaeologistAccusals[accusedArchaeologistAddress].push(sarcoId);

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -2,11 +2,9 @@
 pragma solidity ^0.8.13;
 
 import "../libraries/LibTypes.sol";
-import "hardhat/console.sol";
 import "../storage/LibAppStorage.sol";
 
 contract ViewStateFacet {
-
     /// @notice Gets the total protocol fees from the contract.
     /// @return The total protocol fees
     function getTotalProtocolFees() external view returns (uint256) {

--- a/contracts/libraries/LibBonds.sol
+++ b/contracts/libraries/LibBonds.sol
@@ -45,16 +45,16 @@ library LibBonds {
     /// archaeologist, without respectively increasing their free bond.
     /// @param archaeologist The address of the archaeologist
     /// @param amount The amount to slash
-    function slashArchaeologistLockedBond(address archaeologist, uint256 amount) internal {
+    function decreaseArchaeologistLockedBond(address archaeologist, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
-        // TDOD: Revert if the amount is greater than the current cursed bond (is this really needed?)
-        // if (amount > s.archaeologistProfiles[archaeologist].cursedBond) {
-        //     revert LibErrors.NotEnoughCursedBond(
-        //         s.archaeologistProfiles[archaeologist].cursedBond,
-        //         amount
-        //     );
-        // }
+        // TDOD: Revert if the amount is greater than the current cursed bond
+        if (amount > s.archaeologistProfiles[archaeologist].cursedBond) {
+            revert LibErrors.NotEnoughCursedBond(
+                s.archaeologistProfiles[archaeologist].cursedBond,
+                amount
+            );
+        }
 
         s.archaeologistProfiles[archaeologist].cursedBond -= amount;
     }
@@ -88,7 +88,7 @@ library LibBonds {
         uint256 diggingFeesDue = archaeologist.diggingFeePerSecond *
             (sarcophagus.resurrectionTime - sarcophagus.previousRewrapTime);
 
-        s.archaeologistProfiles[archaeologist.archAddress].freeBond -= diggingFeesDue;
+        decreaseFreeBond(archaeologist.archAddress, diggingFeesDue);
         s.archaeologistProfiles[archaeologist.archAddress].cursedBond += diggingFeesDue;
 
         s.archaeologistSarcophagi[archaeologist.archAddress].push(sarcoId);
@@ -111,7 +111,7 @@ library LibBonds {
         uint256 amount = cursedArchaeologist.diggingFeePerSecond *
             (sarcophagus.resurrectionTime - sarcophagus.previousRewrapTime);
 
-        s.archaeologistProfiles[archaeologistAddress].cursedBond -= amount;
+        decreaseArchaeologistLockedBond(archaeologistAddress, amount);
         s.archaeologistProfiles[archaeologistAddress].freeBond += amount;
         s.archaeologistRewards[archaeologistAddress] += amount;
     }

--- a/contracts/libraries/LibBonds.sol
+++ b/contracts/libraries/LibBonds.sol
@@ -97,8 +97,7 @@ library LibBonds {
         return diggingFeesDue;
     }
 
-    /// @notice Calculates an archaeologist's cursed bond and frees them
-    /// (unlocks the cursed bond).
+    /// @notice Calculates and unlocks an archaeologist's cursed bond. Pays due digging fees to the archaeologist.
     /// @param sarcoId the identifier of the sarcophagus to free the archaeologist from
     /// @param archaeologistAddress the address of the archaeologist to free
     function freeArchaeologist(bytes32 sarcoId, address archaeologistAddress) internal {

--- a/contracts/libraries/LibBonds.sol
+++ b/contracts/libraries/LibBonds.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.13;
 
 import "../storage/LibAppStorage.sol";
 import "../libraries/LibTypes.sol";
-import {LibErrors} from "../libraries/LibErrors.sol";
+import {LibErrors} from "./LibErrors.sol";
+
+import "../facets/EmbalmerFacet.sol";
 
 library LibBonds {
     /// @notice Decreases the amount stored in the freeBond mapping for an
@@ -40,64 +42,59 @@ library LibBonds {
     }
 
     /// @notice Decreases the amount stored in the cursedBond mapping for an
-    /// archaeologist. Reverts if the archaeologist's cursed bond is lower than
-    /// the amount.
-    /// @param archaeologist The address of the archaeologist whose
-    /// cursed bond is being decreased
-    /// @param amount The amount to decrease the cursed bond by
-    function decreaseCursedBond(address archaeologist, uint256 amount) internal {
+    /// archaeologist, without respectively increasing their free bond.
+    /// @param archaeologist The address of the archaeologist
+    /// @param amount The amount to slash
+    function slashArchaeologistLockedBond(address archaeologist, uint256 amount) internal {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
-        // Revert if the amount is greater than the current cursed bond
-        if (amount > s.archaeologistProfiles[archaeologist].cursedBond) {
-            revert LibErrors.NotEnoughCursedBond(
-                s.archaeologistProfiles[archaeologist].cursedBond,
-                amount
-            );
-        }
+        // TDOD: Revert if the amount is greater than the current cursed bond (is this really needed?)
+        // if (amount > s.archaeologistProfiles[archaeologist].cursedBond) {
+        //     revert LibErrors.NotEnoughCursedBond(
+        //         s.archaeologistProfiles[archaeologist].cursedBond,
+        //         amount
+        //     );
+        // }
 
-        // Decrease the cursed bond amount
         s.archaeologistProfiles[archaeologist].cursedBond -= amount;
     }
 
-    /// @notice Increases the amount stored in the cursedBond mapping for an
-    /// archaeologist.
-    /// @param archaeologist The address of the archaeologist whose
-    /// cursed bond is being decreased
-    /// @param amount The amount to decrease the cursed bond by
-    function increaseCursedBond(address archaeologist, uint256 amount) internal {
+    /// @notice Bonds the archaeologist to a sarcophagus.
+    /// This does the following:
+    ///   - adds the archaeologist's curse params and address to the sarcophagus
+    ///   - calculates digging fees to be locked and later paid to archaeologist
+    ///   - locks this amount from archaeologist's free bond; increases cursedBond by same
+    ///   - Adds the sarcophagus' id to the archaeologist's record of bonded sarcophagi
+    /// @param sarcoId Id of the sarcophagus with which to curse the archaeologist
+    /// @param archaeologist The archaologist to curse, with associated parameters of the curse
+    ///
+    /// @return the amount of digging fees due the embalmer for this curse
+    function curseArchaeologist(
+        bytes32 sarcoId,
+        EmbalmerFacet.CurseParams calldata archaeologist
+    ) internal returns (uint256) {
         AppStorage storage s = LibAppStorage.getAppStorage();
+        LibTypes.Sarcophagus storage sarcophagus = s.sarcophagi[sarcoId];
 
-        // Increase the cursed bond amount
-        s.archaeologistProfiles[archaeologist].cursedBond += amount;
+        sarcophagus.cursedArchaeologists[archaeologist.archAddress] = LibTypes.CursedArchaeologist({
+            publicKey: archaeologist.publicKey,
+            privateKey: 0,
+            isAccused: false,
+            diggingFeePerSecond: archaeologist.diggingFeePerSecond
+        });
+        sarcophagus.cursedArchaeologistAddresses.push(archaeologist.archAddress);
+
+        // Calculate digging fees due for this time period (creationTime/previousRewrapTime -> resurrectionTime)
+        uint256 diggingFeesDue = archaeologist.diggingFeePerSecond *
+            (sarcophagus.resurrectionTime - sarcophagus.previousRewrapTime);
+
+        s.archaeologistProfiles[archaeologist.archAddress].freeBond -= diggingFeesDue;
+        s.archaeologistProfiles[archaeologist.archAddress].cursedBond += diggingFeesDue;
+
+        s.archaeologistSarcophagi[archaeologist.archAddress].push(sarcoId);
+
+        return diggingFeesDue;
     }
-
-    /// @notice Locks up the archaeologist's bond, decreasing the
-    /// archaeologist's free bond by an amount and increasing the
-    /// archaeologist's cursed bond by the same amount.
-    /// @param archaeologist The address of the archaeologist
-    /// @param amount The amount to lock up
-    function lockUpBond(address archaeologist, uint256 amount) internal {
-        // Decrease the free bond amount
-        decreaseFreeBond(archaeologist, amount);
-
-        // Increase the cursed bond amount
-        increaseCursedBond(archaeologist, amount);
-    }
-
-    /// @notice Unlocks the archaeologist's bond, increasing the
-    /// archaeologist's free bond by an amount and decreasing the
-    /// archaeologist's cursed bond by the same amount.
-    /// @param archaeologist The address of the archaeologist
-    /// @param amount The amount to unlock
-    function unlockBond(address archaeologist, uint256 amount) internal {
-        // Decrease the cursed bond amount
-        decreaseCursedBond(archaeologist, amount);
-
-        // Increase the free bond amount
-        increaseFreeBond(archaeologist, amount);
-    }
-
 
     /// @notice Calculates an archaeologist's cursed bond and frees them
     /// (unlocks the cursed bond).
@@ -105,12 +102,17 @@ library LibBonds {
     /// @param archaeologistAddress the address of the archaeologist to free
     function freeArchaeologist(bytes32 sarcoId, address archaeologistAddress) internal {
         AppStorage storage s = LibAppStorage.getAppStorage();
+        LibTypes.Sarcophagus storage sarcophagus = s.sarcophagi[sarcoId];
 
         LibTypes.CursedArchaeologist storage cursedArchaeologist = s
             .sarcophagi[sarcoId]
             .cursedArchaeologists[archaeologistAddress];
 
-        // Free up the archaeologist's locked bond
-        unlockBond(archaeologistAddress, cursedArchaeologist.diggingFee);
+        uint256 amount = cursedArchaeologist.diggingFeePerSecond *
+            (sarcophagus.resurrectionTime - sarcophagus.previousRewrapTime);
+
+        s.archaeologistProfiles[archaeologistAddress].cursedBond -= amount;
+        s.archaeologistProfiles[archaeologistAddress].freeBond += amount;
+        s.archaeologistRewards[archaeologistAddress] += amount;
     }
 }

--- a/contracts/libraries/LibBonds.sol
+++ b/contracts/libraries/LibBonds.sol
@@ -71,7 +71,8 @@ library LibBonds {
     /// @return the amount of digging fees due the embalmer for this curse
     function curseArchaeologist(
         bytes32 sarcoId,
-        EmbalmerFacet.CurseParams calldata archaeologist
+        EmbalmerFacet.CurseParams calldata archaeologist,
+        uint256 index
     ) internal returns (uint256) {
         AppStorage storage s = LibAppStorage.getAppStorage();
         LibTypes.Sarcophagus storage sarcophagus = s.sarcophagi[sarcoId];
@@ -82,7 +83,7 @@ library LibBonds {
             isAccused: false,
             diggingFeePerSecond: archaeologist.diggingFeePerSecond
         });
-        sarcophagus.cursedArchaeologistAddresses.push(archaeologist.archAddress);
+        sarcophagus.cursedArchaeologistAddresses[index] = archaeologist.archAddress;
 
         // Calculate digging fees due for this time period (creationTime/previousRewrapTime -> resurrectionTime)
         uint256 diggingFeesDue = archaeologist.diggingFeePerSecond *

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -8,6 +8,7 @@ library LibTypes {
     struct Sarcophagus {
         // never zero - use for existence checks
         uint256 resurrectionTime;
+        uint256 previousRewrapTime;
         // todo: run gas cost evaluation on storing isCompromised vs looping through stored archaeologists and checking isAccused
         bool isCompromised;
         bool isCleaned;
@@ -26,13 +27,13 @@ library LibTypes {
         bytes publicKey;
         bytes32 privateKey;
         bool isAccused;
-        uint256 diggingFee;
+        uint256 diggingFeePerSecond;
     }
 
     struct ArchaeologistProfile {
         bool exists; // todo: use peerid.length instead of exists
         string peerId;
-        uint256 minimumDiggingFee;
+        uint256 minimumDiggingFeePerSecond;
         uint256 maximumRewrapInterval;
         uint256 freeBond;
         uint256 cursedBond;

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -107,6 +107,7 @@ library LibUtils {
     }
 
     /// @notice Calculates the protocol fees to be taken from the embalmer.
+    /// @param totalDiggingFees to be paid. Protocol fee is a percentage of this
     /// @return The protocol fees amount
     function calculateProtocolFees(uint256 totalDiggingFees) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.getAppStorage();

--- a/test/facets/archaeologist/publishPrivateKey.spec.ts
+++ b/test/facets/archaeologist/publishPrivateKey.spec.ts
@@ -1,6 +1,6 @@
 import "@nomicfoundation/hardhat-chai-matchers";
 import { getContracts } from "../helpers/contracts";
-import { registerSarcophagusWithArchaeologists } from "../helpers/sarcophagus";
+import { createSarcophagusWithRegisteredCursedArchaeologists } from "../helpers/sarcophagus";
 import { expect } from "chai";
 import {
   accuseArchaeologistsOnSarcophagus,
@@ -12,6 +12,7 @@ import {
   getArchaeologistLockedBondSarquitos,
 } from "../helpers/bond";
 import { accountGenerator } from "../helpers/accounts";
+import { BigNumber } from "ethers";
 
 const { deployments, ethers } = require("hardhat");
 
@@ -22,11 +23,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
     accountGenerator.index = 0;
   });
 
-  describe("Validates parameters. Should revert if:", function () {
-    it("no sarcophagus with the supplied id exists", async function () {
+  describe("Validates parameters", function () {
+    it("Reverts if no sarcophagus with the supplied id exists", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       const tx = archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -40,10 +43,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         `SarcophagusDoesNotExist`
       );
     });
-    it("the sarcophagus has been compromised", async function () {
+
+    it("Reverts if the sarcophagus has been compromised", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await compromiseSarcophagus(sarcophagusData, archaeologists);
 
@@ -60,10 +66,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         `SarcophagusCompromised`
       );
     });
-    it("the sarcophagus has been buried", async function () {
+
+    it("Reverts if the sarcophagus has been buried", async function () {
       const { archaeologistFacet, embalmerFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await embalmerFacet
         .connect(sarcophagusData.embalmer)
@@ -82,10 +91,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         `SarcophagusInactive`
       );
     });
-    it("the resurrection time has not passed", async function () {
+
+    it("Reverts if the resurrection time has not passed", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       const tx = archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -100,10 +112,12 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("the grace period has passed", async function () {
+    it("Reverts if the grace period has passed", async function () {
       const { archaeologistFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       const gracePeriod = await viewStateFacet.getGracePeriod();
 
       await time.increaseTo(
@@ -123,10 +137,12 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("the sender is not an archaeologist on the sarcophagus", async function () {
+    it("Reverts if the sender is not an archaeologist on the sarcophagus", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
 
@@ -141,10 +157,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         `ArchaeologistNotOnSarcophagus`
       );
     });
-    it("the archaeologist has been accused", async function () {
+
+    it("Reverts if the archaeologist has been accused", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await accuseArchaeologistsOnSarcophagus(
         1,
@@ -165,10 +184,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         `ArchaeologistHasBeenAccused`
       );
     });
-    it("the archaeologist has already published their key", async function () {
+
+    it("Reverts if the archaeologist has already published their key", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       await archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -187,10 +209,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         `ArchaeologistAlreadyPublishedPrivateKey`
       );
     });
-    it("the private key being published does not match the public key on the cursedArchaeologist", async function () {
+
+    it("Reverts if the private key being published does not match the public key on the cursedArchaeologist", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       const tx = archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -208,8 +233,10 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
   describe("Successfully publishes a private key", function () {
     it("updates the cursedArchaeologist on the sarcophagus with the privateKey that was published", async function () {
       const { archaeologistFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       await archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -227,10 +254,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         archaeologists[0].privateKey
       );
     });
+
     it("returns the locked bond for the cursed archaeologist equal to their digging fees on the sarcophagus", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       // save starting free and locked bonds for all archaeologists
       const prePublishFreeBondSarquitos =
@@ -255,18 +285,28 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
           archaeologists[0].archAddress
         );
 
+      const diggingFeesDue = BigNumber.from(
+        archaeologists[0].diggingFeePerSecondSarquito
+      ).mul(
+        sarcophagusData.resurrectionTimeSeconds -
+          sarcophagusData.creationTimeSeconds
+      );
+
       expect(postPublishFreeBondSarquitos).to.equal(
-        prePublishFreeBondSarquitos.add(archaeologists[0].diggingFeeSarquitos)
+        prePublishFreeBondSarquitos.add(diggingFeesDue)
       );
 
       expect(postPublishLockedBondSarquitos).to.equal(
-        prePublishLockedBondSarquitos.sub(archaeologists[0].diggingFeeSarquitos)
+        prePublishLockedBondSarquitos.sub(diggingFeesDue)
       );
     });
+
     it("pays the archaologist their digging fees", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       const tx = archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -276,10 +316,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         );
       await expect(tx).to.emit(archaeologistFacet, `PublishPrivateKey`);
     });
+
     it("stores the sarcoId in archaeologistSuccesses", async function () {
       const { archaeologistFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       await archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))
@@ -299,10 +342,13 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
         );
       await expect(archaeologistSuccessOnSarcophagus).to.equal(true);
     });
+
     it("emits PublishPrivateKey", async function () {
       const { archaeologistFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       const tx = archaeologistFacet
         .connect(await ethers.getSigner(archaeologists[0].archAddress))

--- a/test/facets/archaeologist/publishPrivateKey.spec.ts
+++ b/test/facets/archaeologist/publishPrivateKey.spec.ts
@@ -23,8 +23,8 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
     accountGenerator.index = 0;
   });
 
-  describe("Validates parameters", function () {
-    it("Reverts if no sarcophagus with the supplied id exists", async function () {
+  describe("Validates parameters. Should revert if:", function () {
+    it("no sarcophagus with the supplied id exists", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -44,7 +44,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the sarcophagus has been compromised", async function () {
+    it("the sarcophagus has been compromised", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -67,7 +67,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the sarcophagus has been buried", async function () {
+    it("the sarcophagus has been buried", async function () {
       const { archaeologistFacet, embalmerFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -92,7 +92,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the resurrection time has not passed", async function () {
+    it("the resurrection time has not passed", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -112,7 +112,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the grace period has passed", async function () {
+    it("the grace period has passed", async function () {
       const { archaeologistFacet, viewStateFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -137,7 +137,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the sender is not an archaeologist on the sarcophagus", async function () {
+    it("the sender is not an archaeologist on the sarcophagus", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -158,7 +158,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the archaeologist has been accused", async function () {
+    it("the archaeologist has been accused", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -185,7 +185,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the archaeologist has already published their key", async function () {
+    it("the archaeologist has already published their key", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,
@@ -210,7 +210,7 @@ describe("ArchaeologistFacet.publishPrivateKey", () => {
       );
     });
 
-    it("Reverts if the private key being published does not match the public key on the cursedArchaeologist", async function () {
+    it("the private key being published does not match the public key on the cursedArchaeologist", async function () {
       const { archaeologistFacet } = await getContracts();
       const {
         createdSarcophagusData: sarcophagusData,

--- a/test/facets/embalmer/burySarcophagus.spec.ts
+++ b/test/facets/embalmer/burySarcophagus.spec.ts
@@ -1,6 +1,6 @@
 import "@nomicfoundation/hardhat-chai-matchers";
 import { getContracts } from "../helpers/contracts";
-import { registerSarcophagusWithArchaeologists } from "../helpers/sarcophagus";
+import { createSarcophagusWithRegisteredCursedArchaeologists } from "../helpers/sarcophagus";
 import { expect } from "chai";
 import {
   accuseArchaeologistsOnSarcophagus,
@@ -13,6 +13,7 @@ import {
   getArchaeologistFreeBondSarquitos,
   getArchaeologistLockedBondSarquitos,
 } from "../helpers/bond";
+import { BigNumber } from "ethers";
 
 const { deployments, ethers } = require("hardhat");
 
@@ -26,7 +27,8 @@ describe("EmbalmerFacet.burySarcophagus", () => {
   describe("Validates parameters. Should revert if:", function () {
     it("no sarcophagus with the supplied id exists", async function () {
       const { embalmerFacet } = await getContracts();
-      const { sarcophagusData } = await registerSarcophagusWithArchaeologists();
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists();
 
       const tx = embalmerFacet
         .connect(sarcophagusData.embalmer)
@@ -41,8 +43,10 @@ describe("EmbalmerFacet.burySarcophagus", () => {
     });
     it("the sarcophagus has been compromised", async function () {
       const { embalmerFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await compromiseSarcophagus(sarcophagusData, archaeologists);
 
@@ -57,7 +61,8 @@ describe("EmbalmerFacet.burySarcophagus", () => {
     });
     it("the sarcophagus has been buried", async function () {
       const { embalmerFacet } = await getContracts();
-      const { sarcophagusData } = await registerSarcophagusWithArchaeologists();
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await embalmerFacet
         .connect(sarcophagusData.embalmer)
@@ -74,7 +79,8 @@ describe("EmbalmerFacet.burySarcophagus", () => {
     });
     it("the sender is not the embalmer", async function () {
       const { embalmerFacet } = await getContracts();
-      const { sarcophagusData } = await registerSarcophagusWithArchaeologists();
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists();
 
       const tx = embalmerFacet
         .connect(await accountGenerator.newAccount())
@@ -87,7 +93,8 @@ describe("EmbalmerFacet.burySarcophagus", () => {
     });
     it("the resurrection time has passed", async function () {
       const { embalmerFacet } = await getContracts();
-      const { sarcophagusData } = await registerSarcophagusWithArchaeologists();
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists();
 
       await time.increaseTo(sarcophagusData.resurrectionTimeSeconds);
       const tx = embalmerFacet
@@ -104,8 +111,10 @@ describe("EmbalmerFacet.burySarcophagus", () => {
   describe("Successfully buries a sarcophagus with no accusals", function () {
     it("Should pay digging fees to each of the cursed archaeologists", async function () {
       const { embalmerFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       // save starting free and locked bonds for all archaeologists
       const startingArchaeologistRewards = await Promise.all(
@@ -126,19 +135,27 @@ describe("EmbalmerFacet.burySarcophagus", () => {
             const archaeologistPostRewrapRewards =
               await viewStateFacet.getRewards(archaeologist.archAddress);
 
+            const diggingFeesDue = BigNumber.from(
+              archaeologist.diggingFeePerSecondSarquito
+            ).mul(
+              sarcophagusData.resurrectionTimeSeconds -
+                sarcophagusData.creationTimeSeconds
+            );
+
             expect(archaeologistPostRewrapRewards).to.equal(
-              startingArchaeologistRewards[index].add(
-                archaeologist.diggingFeePerSecondSarquito
-              )
+              startingArchaeologistRewards[index].add(diggingFeesDue)
             );
           }
         )
       );
     });
+
     it("Should unlock the bonds of each of the cursed archaeologists", async function () {
       const { embalmerFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       // save starting free and locked bonds for all archaeologists
       const startingArchaeologistBonds = await Promise.all(
@@ -169,24 +186,29 @@ describe("EmbalmerFacet.burySarcophagus", () => {
                 archaeologist.archAddress
               );
 
+            const diggingFeesDue = BigNumber.from(
+              archaeologist.diggingFeePerSecondSarquito
+            ).mul(
+              sarcophagusData.resurrectionTimeSeconds -
+                sarcophagusData.creationTimeSeconds
+            );
+
             expect(archaeologistPostCurseFreeBond).to.equal(
-              startingArchaeologistBonds[index].freeBond.add(
-                archaeologist.diggingFeePerSecondSarquito
-              )
+              startingArchaeologistBonds[index].freeBond.add(diggingFeesDue)
             );
 
             expect(archaeologistPostCurseLockedBond).to.equal(
-              startingArchaeologistBonds[index].lockedBond.sub(
-                archaeologist.diggingFeePerSecondSarquito
-              )
+              startingArchaeologistBonds[index].lockedBond.sub(diggingFeesDue)
             );
           }
         )
       );
     });
+
     it("Should update the resurrectionTime and emit BurySarcophagus", async function () {
       const { embalmerFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData } = await registerSarcophagusWithArchaeologists();
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists();
 
       const tx = embalmerFacet
         .connect(sarcophagusData.embalmer)
@@ -194,15 +216,19 @@ describe("EmbalmerFacet.burySarcophagus", () => {
       const result = await viewStateFacet.getSarcophagus(
         sarcophagusData.sarcoId
       );
+
       expect(result.resurrectionTime).to.equal(ethers.constants.MaxUint256);
       await expect(tx).to.emit(embalmerFacet, "BurySarcophagus");
     });
   });
+
   describe("Successfully buries a sarcophagus with fewer than k accusals", function () {
     it("Should not pay digging fees to the accused cursed archaeologists", async function () {
       const { embalmerFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       // save starting free and locked bonds for all archaeologists
       const startingArchaeologistRewards = await Promise.all(
@@ -238,20 +264,28 @@ describe("EmbalmerFacet.burySarcophagus", () => {
                 startingArchaeologistRewards[index]
               );
             } else {
+              const diggingFeesDue = BigNumber.from(
+                archaeologist.diggingFeePerSecondSarquito
+              ).mul(
+                sarcophagusData.resurrectionTimeSeconds -
+                  sarcophagusData.creationTimeSeconds
+              );
+
               expect(archaeologistPostRewrapRewards).to.equal(
-                startingArchaeologistRewards[index].add(
-                  archaeologist.diggingFeePerSecondSarquito
-                )
+                startingArchaeologistRewards[index].add(diggingFeesDue)
               );
             }
           }
         )
       );
     });
+
     it("Should not increase the free bonds of the accused archaeologists", async function () {
-      const { embalmerFacet, viewStateFacet } = await getContracts();
-      const { sarcophagusData, archaeologists } =
-        await registerSarcophagusWithArchaeologists();
+      const { embalmerFacet } = await getContracts();
+      const {
+        createdSarcophagusData: sarcophagusData,
+        cursedArchaeologists: archaeologists,
+      } = await createSarcophagusWithRegisteredCursedArchaeologists();
 
       const { accusedArchaeologists } = await accuseArchaeologistsOnSarcophagus(
         sarcophagusData.threshold - 1,
@@ -316,6 +350,7 @@ describe("EmbalmerFacet.burySarcophagus", () => {
           }
         )
       );
+
       // check post bury bond on innocent archaeologists has been unlocked
       await Promise.all(
         innocentArchaeologists.map(
@@ -329,15 +364,22 @@ describe("EmbalmerFacet.burySarcophagus", () => {
                 archaeologist.archAddress
               );
 
+            const diggingFeesDue = BigNumber.from(
+              archaeologist.diggingFeePerSecondSarquito
+            ).mul(
+              sarcophagusData.resurrectionTimeSeconds -
+                sarcophagusData.creationTimeSeconds
+            );
+
             expect(archaeologistPostBuryFreeBond).to.equal(
               startingInnocentArchaeologistBonds[index].freeBond.add(
-                archaeologist.diggingFeePerSecondSarquito
+                diggingFeesDue
               )
             );
 
             expect(archaeologistPostBuryLockedBond).to.equal(
               startingInnocentArchaeologistBonds[index].lockedBond.sub(
-                archaeologist.diggingFeePerSecondSarquito
+                diggingFeesDue
               )
             );
           }

--- a/test/facets/embalmer/burySarcophagus.spec.ts
+++ b/test/facets/embalmer/burySarcophagus.spec.ts
@@ -128,7 +128,7 @@ describe("EmbalmerFacet.burySarcophagus", () => {
 
             expect(archaeologistPostRewrapRewards).to.equal(
               startingArchaeologistRewards[index].add(
-                archaeologist.diggingFeeSarquitos
+                archaeologist.diggingFeePerSecondSarquito
               )
             );
           }
@@ -171,13 +171,13 @@ describe("EmbalmerFacet.burySarcophagus", () => {
 
             expect(archaeologistPostCurseFreeBond).to.equal(
               startingArchaeologistBonds[index].freeBond.add(
-                archaeologist.diggingFeeSarquitos
+                archaeologist.diggingFeePerSecondSarquito
               )
             );
 
             expect(archaeologistPostCurseLockedBond).to.equal(
               startingArchaeologistBonds[index].lockedBond.sub(
-                archaeologist.diggingFeeSarquitos
+                archaeologist.diggingFeePerSecondSarquito
               )
             );
           }
@@ -240,7 +240,7 @@ describe("EmbalmerFacet.burySarcophagus", () => {
             } else {
               expect(archaeologistPostRewrapRewards).to.equal(
                 startingArchaeologistRewards[index].add(
-                  archaeologist.diggingFeeSarquitos
+                  archaeologist.diggingFeePerSecondSarquito
                 )
               );
             }
@@ -331,13 +331,13 @@ describe("EmbalmerFacet.burySarcophagus", () => {
 
             expect(archaeologistPostBuryFreeBond).to.equal(
               startingInnocentArchaeologistBonds[index].freeBond.add(
-                archaeologist.diggingFeeSarquitos
+                archaeologist.diggingFeePerSecondSarquito
               )
             );
 
             expect(archaeologistPostBuryLockedBond).to.equal(
               startingInnocentArchaeologistBonds[index].lockedBond.sub(
-                archaeologist.diggingFeeSarquitos
+                archaeologist.diggingFeePerSecondSarquito
               )
             );
           }

--- a/test/facets/embalmer/createSarcophagus.spec.ts
+++ b/test/facets/embalmer/createSarcophagus.spec.ts
@@ -7,6 +7,7 @@ import {
   createSarcophagusData,
   registerDefaultArchaeologistsAndCreateSignatures,
   createSarcophagusWithRegisteredCursedArchaeologists,
+  diggingFeesPerSecond_10_000_SarcoMonthly,
 } from "../helpers/sarcophagus";
 import {
   ArchaeologistData,
@@ -176,7 +177,7 @@ describe("EmbalmerFacet.createSarcophagus", () => {
           maximumRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
           creationTime: sarcophagusData.creationTime,
-          diggingFeePerSecondSarquito: ethers.utils.parseEther("1000"),
+          diggingFeePerSecondSarquito: diggingFeesPerSecond_10_000_SarcoMonthly,
         }
       );
       archaeologists[0] = unregisteredArchaeologistData;
@@ -207,7 +208,7 @@ describe("EmbalmerFacet.createSarcophagus", () => {
           maximumRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
           creationTime: sarcophagusData.creationTime,
-          diggingFeePerSecondSarquito: ethers.utils.parseEther("1000"),
+          diggingFeePerSecondSarquito: diggingFeesPerSecond_10_000_SarcoMonthly,
         }
       );
       archaeologists[1] = duplicateArchaeologist;

--- a/test/facets/embalmer/rewrapSarcophagus.spec.ts
+++ b/test/facets/embalmer/rewrapSarcophagus.spec.ts
@@ -132,8 +132,8 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
         .rewrapSarcophagus(
           sarcophagusData.sarcoId,
           (await time.latest()) +
-            sarcophagusData.maximumRewrapIntervalSeconds +
-            time.duration.minutes(1)
+          sarcophagusData.maximumRewrapIntervalSeconds +
+          time.duration.minutes(1)
         );
 
       await expect(tx).to.be.revertedWithCustomError(
@@ -173,7 +173,7 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
 
             expect(archaeologistPostRewrapRewards).to.equal(
               startingArchaeologistRewards[index].add(
-                archaeologist.diggingFeeSarquitos
+                archaeologist.diggingFeePerSecondSarquito
               )
             );
           }
@@ -267,7 +267,7 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
             } else {
               expect(archaeologistPostRewrapRewards).to.equal(
                 startingArchaeologistRewards[index].add(
-                  archaeologist.diggingFeeSarquitos
+                  archaeologist.diggingFeePerSecondSarquito
                 )
               );
             }

--- a/test/facets/embalmer/rewrapSarcophagus.spec.ts
+++ b/test/facets/embalmer/rewrapSarcophagus.spec.ts
@@ -132,8 +132,8 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
         .rewrapSarcophagus(
           sarcophagusData.sarcoId,
           (await time.latest()) +
-          sarcophagusData.maximumRewrapIntervalSeconds +
-          time.duration.minutes(1)
+            sarcophagusData.maximumRewrapIntervalSeconds +
+            time.duration.minutes(1)
         );
 
       await expect(tx).to.be.revertedWithCustomError(

--- a/test/facets/helpers/accuse.ts
+++ b/test/facets/helpers/accuse.ts
@@ -35,7 +35,7 @@ export const compromiseSarcophagus = async (
  */
 export const accuseArchaeologistsOnSarcophagus = async (
   count: number,
-  sarcoId: Bytes,
+  sarcoId: string,
   archaeologists: ArchaeologistData[]
 ): Promise<{
   accusedArchaeologists: ArchaeologistData[];
@@ -50,7 +50,7 @@ export const accuseArchaeologistsOnSarcophagus = async (
       async (accusedArchaeologist: ArchaeologistData) =>
         await sign(
           new ethers.Wallet(accusedArchaeologist.privateKey),
-          [sarcoId.toString(), accuser.address],
+          [sarcoId, accuser.address],
           ["bytes32", "address"]
         )
     )

--- a/test/facets/helpers/accuse.ts
+++ b/test/facets/helpers/accuse.ts
@@ -65,13 +65,13 @@ export const accuseArchaeologistsOnSarcophagus = async (
   return { accusedArchaeologists, accuser };
 };
 export const generateAccusalSignature = async (
-  sarcoId: Bytes,
+  sarcoId: string,
   accusedArchaeologistPrivateKey: string,
   accuserAddress: string
 ): Promise<Signature> =>
   await sign(
     new ethers.Wallet(accusedArchaeologistPrivateKey),
-    [sarcoId.toString(), accuserAddress],
+    [sarcoId, accuserAddress],
     ["bytes32", "address"]
   );
 
@@ -79,7 +79,7 @@ export const generateAccusalSignature = async (
  * Given a set of archaeologists and sarcoId, asserts all have the expected accusal status
  * */
 export const verifyAccusalStatusesForArchaeologists = async (
-  sarcoId: Bytes,
+  sarcoId: string,
   archaeologists: ArchaeologistData[],
   isAccused: boolean
 ): Promise<void> => {

--- a/test/facets/helpers/archaeologist.ts
+++ b/test/facets/helpers/archaeologist.ts
@@ -2,6 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { accountGenerator } from "./accounts";
 import { fundAndApproveAccount } from "./sarcoToken";
 import { getContracts } from "./contracts";
+import { BigNumber } from "ethers";
 
 const { ethers } = require("hardhat");
 
@@ -12,7 +13,7 @@ const { ethers } = require("hardhat");
  * freeBondSarco - amount of SARCO to deduct from sarcoBalance and register as free bond
  */
 export interface ArchaeologistParameters {
-  profileMinDiggingFeeSarco: number;
+  profileMinDiggingFeePerSecondSarquito: BigNumber;
   profileMaxRewrapIntervalSeconds: number;
   sarcoBalance: number;
   freeBondSarco: number;
@@ -21,8 +22,9 @@ export interface ArchaeologistParameters {
 /**
  * Registers an archaeologist with the supplied ArchaeologistParameters
  *
- * transfers the archaeologist the specified SARCO balance and approves diamond spending on their behalf
- * registers the archaeologist on the ArchaeologistFacet with the specified freeBond amount (deducted from their balance)
+ * Transfers the archaeologist the specified SARCO balance and approves diamond spending on their behalf
+ *
+ * Registers the archaeologist on the ArchaeologistFacet with the specified freeBond amount (deducted from their balance)
  *
  * @param archaeologistParams
  * @returns the archaeologist's signer
@@ -30,10 +32,6 @@ export interface ArchaeologistParameters {
 export const registerArchaeologist = async (
   archaeologistParams: ArchaeologistParameters
 ): Promise<SignerWithAddress> => {
-  // calculate archaeologist's minimum digging fee and free bond in sarquitos
-  const archMinDiggingFeeSarquitos = ethers.utils
-    .parseEther(archaeologistParams.profileMinDiggingFeeSarco.toString())
-    .toString();
   const archaeologistFreeBondSarquitos = ethers.utils.parseEther(
     archaeologistParams.freeBondSarco.toString()
   );
@@ -51,7 +49,7 @@ export const registerArchaeologist = async (
     .connect(archaeologistSigner)
     .registerArchaeologist(
       peerId,
-      archMinDiggingFeeSarquitos,
+      archaeologistParams.profileMinDiggingFeePerSecondSarquito,
       archaeologistParams.profileMaxRewrapIntervalSeconds,
       archaeologistFreeBondSarquitos
     );

--- a/test/facets/helpers/archaeologist.ts
+++ b/test/facets/helpers/archaeologist.ts
@@ -2,7 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { accountGenerator } from "./accounts";
 import { fundAndApproveAccount } from "./sarcoToken";
 import { getContracts } from "./contracts";
-import { BigNumber } from "ethers";
+import { BigNumberish } from "ethers";
 
 const { ethers } = require("hardhat");
 
@@ -13,7 +13,7 @@ const { ethers } = require("hardhat");
  * freeBondSarco - amount of SARCO to deduct from sarcoBalance and register as free bond
  */
 export interface ArchaeologistParameters {
-  profileMinDiggingFeePerSecondSarquito: BigNumber;
+  profileMinDiggingFeePerSecondSarquito: BigNumberish;
   profileMaxRewrapIntervalSeconds: number;
   sarcoBalance: number;
   freeBondSarco: number;

--- a/test/facets/helpers/archaeologistSignature.ts
+++ b/test/facets/helpers/archaeologistSignature.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BigNumber } from "ethers";
 import { sign } from "../../utils/helpers";
 
 const { ethers } = require("hardhat");
@@ -11,7 +12,7 @@ export interface ArchaeologistData {
   archAddress: string;
   publicKey: string;
   privateKey: string;
-  diggingFeeSarquitos: string;
+  diggingFeePerSecondSarquito: BigNumber;
   v: number;
   r: string;
   s: string;
@@ -25,7 +26,7 @@ export interface SarcophagusNegotiationParams {
   privateKey: string;
   maximumRewrapIntervalSeconds: number;
   creationTime: number;
-  diggingFeeSarco: number;
+  diggingFeePerSecondSarquito: BigNumber;
 }
 
 /**
@@ -39,18 +40,13 @@ export const createArchSignature = async (
   archaeologistSigner: SignerWithAddress,
   sarcophagusParams: SarcophagusNegotiationParams
 ): Promise<ArchaeologistData> => {
-  // calculate sarcophagus' digging fees in sarquitos
-  const sarcophagusDiggingFeeSarquitos = ethers.utils
-    .parseEther(sarcophagusParams.diggingFeeSarco.toString())
-    .toString();
-
   // sign sarcophagus negotiation parameters with archaeologist signer
   const { v, r, s } = await sign(
     archaeologistSigner,
     [
       sarcophagusParams.publicKey,
       sarcophagusParams.maximumRewrapIntervalSeconds.toString(),
-      sarcophagusDiggingFeeSarquitos,
+      sarcophagusParams.diggingFeePerSecondSarquito.toString(),
       sarcophagusParams.creationTime.toString(),
     ],
     ["bytes", "uint256", "uint256", "uint256"]
@@ -58,7 +54,7 @@ export const createArchSignature = async (
 
   return {
     archAddress: archaeologistSigner.address,
-    diggingFeeSarquitos: sarcophagusDiggingFeeSarquitos,
+    diggingFeePerSecondSarquito: sarcophagusParams.diggingFeePerSecondSarquito,
     publicKey: sarcophagusParams.publicKey,
     privateKey: sarcophagusParams.privateKey,
     v,

--- a/test/facets/helpers/archaeologistSignature.ts
+++ b/test/facets/helpers/archaeologistSignature.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber } from "ethers";
+import { BigNumberish } from "ethers";
 import { sign } from "../../utils/helpers";
 
 const { ethers } = require("hardhat");
@@ -12,7 +12,7 @@ export interface ArchaeologistData {
   archAddress: string;
   publicKey: string;
   privateKey: string;
-  diggingFeePerSecondSarquito: BigNumber;
+  diggingFeePerSecondSarquito: BigNumberish;
   v: number;
   r: string;
   s: string;
@@ -26,7 +26,7 @@ export interface SarcophagusNegotiationParams {
   privateKey: string;
   maximumRewrapIntervalSeconds: number;
   creationTime: number;
-  diggingFeePerSecondSarquito: BigNumber;
+  diggingFeePerSecondSarquito: BigNumberish;
 }
 
 /**

--- a/test/facets/helpers/clean.ts
+++ b/test/facets/helpers/clean.ts
@@ -8,7 +8,7 @@ import time from "../../utils/time";
  */
 export const setTimeToEmbalmerClaimWindowStart = async (
   resurrectionTimeSeconds: number
-) => {
+): Promise<void> => {
   const { viewStateFacet } = await getContracts();
   const publishDeadline =
     resurrectionTimeSeconds +
@@ -23,7 +23,7 @@ export const setTimeToEmbalmerClaimWindowStart = async (
  */
 export const setTimeToAfterEmbalmerClaimWindowEnd = async (
   resurrectionTimeSeconds: number
-) => {
+): Promise<void> => {
   const { viewStateFacet } = await getContracts();
   const embalmerClaimWindow = await viewStateFacet.getEmbalmerClaimWindow();
   const publishDeadline =

--- a/test/facets/helpers/diggingFees.ts
+++ b/test/facets/helpers/diggingFees.ts
@@ -17,11 +17,16 @@ export const getArchaeologistLockedBondSarquitos = async (
  * Calculates the total digging fees for a set of archaeologists
  * */
 export const getTotalDiggingFeesSarquitos = (
-  archaeologists: ArchaeologistData[]
+  archaeologists: ArchaeologistData[],
+  resurrectionInterval: number
 ): BigNumber =>
   archaeologists.reduce(
     (sum: BigNumber, archaeologist: ArchaeologistData) =>
-      sum.add(BigNumber.from(archaeologist.diggingFeeSarquitos)),
+      sum.add(
+        BigNumber.from(archaeologist.diggingFeePerSecondSarquito).mul(
+          resurrectionInterval
+        )
+      ),
     BigNumber.from(0)
   );
 
@@ -29,10 +34,14 @@ export const getTotalDiggingFeesSarquitos = (
  * Calculates the total digging fees for a set of archaeologists plus the protocol fees (incurred on rewrap and create)
  * */
 export const getDiggingFeesPlusProtocolFeesSarquitos = async (
-  archaeologists: ArchaeologistData[]
+  archaeologists: ArchaeologistData[],
+  resurrectionInterval: number
 ): Promise<BigNumber> => {
   const { viewStateFacet } = await getContracts();
-  const totalDiggingFees = getTotalDiggingFeesSarquitos(archaeologists);
+  const totalDiggingFees = getTotalDiggingFeesSarquitos(
+    archaeologists,
+    resurrectionInterval
+  );
   return totalDiggingFees.add(
     totalDiggingFees
       .mul(await viewStateFacet.getProtocolFeeBasePercentage())

--- a/test/facets/helpers/sarcophagus.ts
+++ b/test/facets/helpers/sarcophagus.ts
@@ -13,10 +13,10 @@ import {
 } from "./archaeologistSignature";
 import { getContracts } from "./contracts";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber, BigNumberish, Bytes } from "ethers";
+import { BigNumberish } from "ethers";
 import { BytesLike } from "ethers/lib/utils";
-import { ethers } from "hardhat";
 
+const { ethers } = require("hardhat");
 const crypto = require("crypto");
 
 export const diggingFeesPerSecond_10_000_SarcoMonthly = "4000000000000000";
@@ -33,7 +33,7 @@ export interface SarcophagusData {
   recipientAddress: string;
   resurrectionTimeSeconds: number;
   maximumRewrapIntervalSeconds: number;
-  creationTime: number;
+  creationTimeSeconds: number;
   threshold: number;
   privateKeys: string[];
   publicKeys: string[];
@@ -54,7 +54,7 @@ export const createSarcophagusData = async (params: {
   resurrectionTime?: number;
   sarcoId?: string;
   name?: string;
-  creationTime?: number;
+  creationTimeSeconds?: number;
   recipientAddress?: string;
   embalmerAddress?: string;
   embalmerFunds?: number;
@@ -81,10 +81,12 @@ export const createSarcophagusData = async (params: {
     params.sarcoId ?? ethers.utils.solidityKeccak256(["string"], [name]);
 
   // get the current time which will be signed off on by archaeologists as the negotiation timestamp
-  const creationTime = params.creationTime ?? (await time.latest());
+  const creationTimeSeconds =
+    params.creationTimeSeconds ?? (await time.latest());
 
   const resurrectionTimeSeconds =
-    params.resurrectionTime ?? creationTime + maximumRewrapIntervalSeconds;
+    params.resurrectionTime ??
+    creationTimeSeconds + maximumRewrapIntervalSeconds;
 
   // generate the key pairs for the sarcophagus
   const privateKeys = Array.from(
@@ -103,7 +105,7 @@ export const createSarcophagusData = async (params: {
     resurrectionTimeSeconds,
     maximumRewrapIntervalSeconds,
     threshold,
-    creationTime,
+    creationTimeSeconds,
     privateKeys,
     publicKeys,
   };
@@ -134,7 +136,7 @@ export const registerDefaultArchaeologistsAndCreateSignatures = async (
           privateKey,
           maximumRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
-          creationTime: sarcophagusData.creationTime,
+          creationTime: sarcophagusData.creationTimeSeconds,
           diggingFeePerSecondSarquito: diggingFeesPerSecond_10_000_SarcoMonthly,
         },
         {
@@ -239,7 +241,7 @@ export const buildCreateSarcophagusArgs = (
       resurrectionTime: sarcophagusData.resurrectionTimeSeconds,
       maximumRewrapInterval: sarcophagusData.maximumRewrapIntervalSeconds,
       threshold: sarcophagusData.threshold,
-      creationTime: sarcophagusData.creationTime,
+      creationTime: sarcophagusData.creationTimeSeconds,
     },
     archaeologists.map((archaeologist: ArchaeologistData) => ({
       archAddress: archaeologist.archAddress,

--- a/test/facets/helpers/sarcophagus.ts
+++ b/test/facets/helpers/sarcophagus.ts
@@ -19,6 +19,8 @@ import { ethers } from "hardhat";
 
 const crypto = require("crypto");
 
+export const diggingFeesPerSecond_10_000_SarcoMonthly = "4000000000000000";
+
 /**
  * Contains information on a test sarcophagus
  * used to generate archaeologists and signatures and register a sarcophagus
@@ -133,11 +135,11 @@ export const registerDefaultArchaeologistsAndCreateSignatures = async (
           maximumRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
           creationTime: sarcophagusData.creationTime,
-          diggingFeePerSecondSarquito: ethers.utils.parseEther("1000"),
+          diggingFeePerSecondSarquito: diggingFeesPerSecond_10_000_SarcoMonthly,
         },
         {
           profileMinDiggingFeePerSecondSarquito:
-            ethers.utils.parseEther("1000"),
+            diggingFeesPerSecond_10_000_SarcoMonthly,
           profileMaxRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
           sarcoBalance: 10_000,

--- a/test/facets/helpers/sarcophagus.ts
+++ b/test/facets/helpers/sarcophagus.ts
@@ -15,16 +15,17 @@ import { getContracts } from "./contracts";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber, BigNumberish, Bytes } from "ethers";
 import { BytesLike } from "ethers/lib/utils";
-const crypto = require("crypto");
+import { ethers } from "hardhat";
 
-const { ethers } = require("hardhat");
+const crypto = require("crypto");
 
 /**
  * Contains information on a test sarcophagus
  * used to generate archaeologists and signatures and register a sarcophagus
  */
 export interface SarcophagusData {
-  sarcoId: Bytes;
+  sarcoId: string;
+  // sarcoId: Bytes;
   name: string;
   embalmer: SignerWithAddress;
   recipientAddress: string;
@@ -56,47 +57,32 @@ export const createSarcophagusData = async (params: {
   embalmerAddress?: string;
   embalmerFunds?: number;
 }): Promise<SarcophagusData> => {
-  const threshold = params.threshold !== undefined ? params.threshold : 3;
-  const totalShares =
-    params.totalArchaeologists !== undefined ? params.totalArchaeologists : 5;
+  const threshold = params.threshold ?? 3;
+  const totalShares = params.totalArchaeologists ?? 5;
   const maximumRewrapIntervalSeconds =
-    params.maximumRewrapIntervalSeconds !== undefined
-      ? params.maximumRewrapIntervalSeconds
-      : await time.duration.weeks(4);
+    params.maximumRewrapIntervalSeconds ?? time.duration.weeks(4);
 
   // generate new accounts for an embalmer and a recipient
   const embalmerAddress =
-    params.embalmerAddress !== undefined
-      ? params.embalmerAddress
-      : (await accountGenerator.newAccount()).address;
+    params.embalmerAddress ?? (await accountGenerator.newAccount()).address;
   const embalmer = await ethers.getSigner(embalmerAddress);
+
   await fundAndApproveAccount(embalmer, params.embalmerFunds || 100_000);
 
   const recipientAddress =
-    params.recipientAddress !== undefined
-      ? params.recipientAddress
-      : (await accountGenerator.newAccount()).address;
+    params.recipientAddress ?? (await accountGenerator.newAccount()).address;
 
   // create a unique name for the sarcophagus and derive the id
   const name =
-    params.name !== undefined
-      ? params.name
-      : `Sarcophagus by ${embalmerAddress} for ${recipientAddress}`;
+    params.name ?? `Sarcophagus by ${embalmerAddress} for ${recipientAddress}`;
   const sarcoId =
-    params.sarcoId !== undefined
-      ? params.sarcoId
-      : ethers.utils.solidityKeccak256(["string"], [name]);
+    params.sarcoId ?? ethers.utils.solidityKeccak256(["string"], [name]);
 
   // get the current time which will be signed off on by archaeologists as the negotiation timestamp
-  const creationTime =
-    params.creationTime !== undefined
-      ? params.creationTime
-      : await time.latest();
+  const creationTime = params.creationTime ?? (await time.latest());
 
   const resurrectionTimeSeconds =
-    params.resurrectionTime !== undefined
-      ? params.resurrectionTime
-      : creationTime + maximumRewrapIntervalSeconds;
+    params.resurrectionTime ?? creationTime + maximumRewrapIntervalSeconds;
 
   // generate the key pairs for the sarcophagus
   const privateKeys = Array.from(
@@ -126,12 +112,12 @@ export const createSarcophagusData = async (params: {
  * Creates archaeologist signatures on the key shares and sarcophagus negotiation parameters
  *
  * Sets default values on the archaeologists:
- *  profileMinDiggingFee: 100
+ *  profileMinDiggingFeePerSecondSarquito: 1000
  *  profileMaxRewrapIntervalSeconds: uses max rewrap interval set on the sarcophagus
  *  sarcoBalance: 10_000
  *  freeBondSarco: 10_000
  * and on the sarcophagus/archaeologist agreement:
- *  diggingFeeSarco: 100
+ *  diggingFeePerSecondSarco: 100
  *
  * @param sarcophagusData
  */
@@ -147,10 +133,11 @@ export const registerDefaultArchaeologistsAndCreateSignatures = async (
           maximumRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
           creationTime: sarcophagusData.creationTime,
-          diggingFeeSarco: 100,
+          diggingFeePerSecondSarquito: ethers.utils.parseEther("1000"),
         },
         {
-          profileMinDiggingFeeSarco: 100,
+          profileMinDiggingFeePerSecondSarquito:
+            ethers.utils.parseEther("1000"),
           profileMaxRewrapIntervalSeconds:
             sarcophagusData.maximumRewrapIntervalSeconds,
           sarcoBalance: 10_000,
@@ -180,40 +167,38 @@ export const registerArchaeologistAndCreateSignature = async (
 
 /**
  * Creates a sarcophagus with the supplied parameters
- * funds the embalmer account
- * generates and registers a default archaeologist responsible for each keyshare
- * @param params
+ *
+ * Funds the embalmer account.
+ *
+ * Generates and registers a default archaeologist responsible for each keyshare
+ * @param params Basic Sarco creation params
  */
-export const registerSarcophagusWithArchaeologists = async (params?: {
-  totalArchaeologists?: number;
-  threshold?: number;
-  maximumRewrapIntervalSeconds?: number;
-}): Promise<{
-  archaeologists: ArchaeologistData[];
-  sarcophagusData: SarcophagusData;
-}> => {
-  const sarcophagusData = await createSarcophagusData({
-    threshold: params?.threshold,
-    totalArchaeologists: params?.totalArchaeologists,
-    maximumRewrapIntervalSeconds: params?.maximumRewrapIntervalSeconds,
-  });
+export const createSarcophagusWithRegisteredCursedArchaeologists =
+  async (params?: {
+    totalArchaeologists?: number;
+    threshold?: number;
+    maximumRewrapIntervalSeconds?: number;
+  }): Promise<{
+    cursedArchaeologists: ArchaeologistData[];
+    createdSarcophagusData: SarcophagusData;
+  }> => {
+    const sarcophagusData = await createSarcophagusData({ ...params });
 
-  // register archaeologist profiles for each key and create a signature from each archaeologist
-  const archaeologists = await registerDefaultArchaeologistsAndCreateSignatures(
-    sarcophagusData
-  );
+    // register archaeologist profiles for each key and create a signature from each archaeologist
+    const archaeologists =
+      await registerDefaultArchaeologistsAndCreateSignatures(sarcophagusData);
 
-  await (await getContracts()).embalmerFacet
-    .connect(sarcophagusData.embalmer)
-    .createSarcophagus(
-      ...buildCreateSarcophagusArgs(sarcophagusData, archaeologists)
-    );
+    await (await getContracts()).embalmerFacet
+      .connect(sarcophagusData.embalmer)
+      .createSarcophagus(
+        ...buildCreateSarcophagusArgs(sarcophagusData, archaeologists)
+      );
 
-  return {
-    sarcophagusData,
-    archaeologists,
+    return {
+      createdSarcophagusData: sarcophagusData,
+      cursedArchaeologists: archaeologists,
+    };
   };
-};
 
 /**
  * Formats a sarcophagusData object and set of archaeologists to be passed into createSarcophagus contract call
@@ -236,7 +221,7 @@ export const buildCreateSarcophagusArgs = (
   },
   selectedArchaeologists: {
     archAddress: string;
-    diggingFee: BigNumberish;
+    diggingFeePerSecond: BigNumberish;
     publicKey: BytesLike;
     v: BigNumberish;
     r: BytesLike;
@@ -257,7 +242,7 @@ export const buildCreateSarcophagusArgs = (
     archaeologists.map((archaeologist: ArchaeologistData) => ({
       archAddress: archaeologist.archAddress,
       publicKey: archaeologist.publicKey,
-      diggingFee: BigNumber.from(archaeologist.diggingFeeSarquitos),
+      diggingFeePerSecond: archaeologist.diggingFeePerSecondSarquito,
       v: archaeologist.v,
       r: archaeologist.r,
       s: archaeologist.s,

--- a/test/facets/thirdparty/clean.spec.ts
+++ b/test/facets/thirdparty/clean.spec.ts
@@ -50,6 +50,7 @@ describe("ThirdPartyFacet.clean", () => {
         `SarcophagusDoesNotExist`
       );
     });
+
     it("called by embalmer after the embalmerCleanWindow has passed", async function () {
       const { thirdPartyFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -66,6 +67,7 @@ describe("ThirdPartyFacet.clean", () => {
         `EmbalmerClaimWindowPassed`
       );
     });
+
     it("called by admin before the embalmerCleanWindow has passed but after the resurrectionTime + gracePeriod have passed", async function () {
       const { thirdPartyFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -81,6 +83,7 @@ describe("ThirdPartyFacet.clean", () => {
         `TooEarlyForAdminClean`
       );
     });
+
     it("called by third party during embalmerClaimWindow", async function () {
       const { thirdPartyFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -98,6 +101,7 @@ describe("ThirdPartyFacet.clean", () => {
         `SenderNotEmbalmerOrAdmin`
       );
     });
+
     it("called by third party after embalmerClaimWindow", async function () {
       const { thirdPartyFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -136,6 +140,7 @@ describe("ThirdPartyFacet.clean", () => {
         `SarcophagusCompromised`
       );
     });
+
     it("sarcophagus is cleaned", async function () {
       const { thirdPartyFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -156,6 +161,7 @@ describe("ThirdPartyFacet.clean", () => {
         `SarcophagusAlreadyCleaned`
       );
     });
+
     it("sarcophagus is buried", async function () {
       const { embalmerFacet, thirdPartyFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -193,6 +199,7 @@ describe("ThirdPartyFacet.clean", () => {
 
       await expect(tx).to.emit(thirdPartyFacet, `Clean`);
     });
+
     it("sets isCleaned to true on the sarcophagus", async function () {
       const { thirdPartyFacet, viewStateFacet } = await getContracts();
       const { createdSarcophagusData: sarcophagusData } =
@@ -286,6 +293,7 @@ describe("ThirdPartyFacet.clean", () => {
         await getSarquitoBalance(sarcophagusData.embalmer.address)
       ).to.equal(embalmerPreCleanSarquitoBalance);
     });
+
     it("does not transfer bonds or digging fees for archaeologists that have published their key shares", async function () {
       const { thirdPartyFacet, viewStateFacet } = await getContracts();
       const {
@@ -440,10 +448,17 @@ describe("ThirdPartyFacet.clean", () => {
             const balanceAfterClean = await getArchaeologistLockedBondSarquitos(
               nonPublishingArchaeologist.archAddress
             );
+            const diggingFeesDue = BigNumber.from(
+              nonPublishingArchaeologist.diggingFeePerSecondSarquito
+            ).mul(
+              sarcophagusData.resurrectionTimeSeconds -
+                sarcophagusData.creationTimeSeconds
+            );
+
             expect(balanceAfterClean).to.equal(
               nonPublishingArchaeologistAddressesToInitialLockedBondsSarquitos
                 .get(nonPublishingArchaeologist.archAddress)
-                ?.sub(nonPublishingArchaeologist.diggingFeePerSecondSarquito)
+                ?.sub(diggingFeesDue)
             );
           }
         )
@@ -463,6 +478,7 @@ describe("ThirdPartyFacet.clean", () => {
         embalmerPreCleanSarquitoBalance.add(combinedDiggingFeesSarquito.mul(2))
       );
     });
+
     it("does not transfer any funds to the embalmer if all archaeologists have supplied keyshares", async function () {
       const { thirdPartyFacet } = await getContracts();
       const {
@@ -539,10 +555,18 @@ describe("ThirdPartyFacet.clean", () => {
             const balanceAfterClean = await getArchaeologistLockedBondSarquitos(
               nonPublishingArchaeologist.archAddress
             );
+
+            const diggingFeesDue = BigNumber.from(
+              nonPublishingArchaeologist.diggingFeePerSecondSarquito
+            ).mul(
+              sarcophagusData.resurrectionTimeSeconds -
+                sarcophagusData.creationTimeSeconds
+            );
+
             expect(balanceAfterClean).to.equal(
               nonPublishingArchaeologistAddressesToInitialLockedBondsSarquitos
                 .get(nonPublishingArchaeologist.archAddress)
-                ?.sub(nonPublishingArchaeologist.diggingFeePerSecondSarquito)
+                ?.sub(diggingFeesDue)
             );
           }
         )
@@ -561,6 +585,7 @@ describe("ThirdPartyFacet.clean", () => {
         startingProtocolFees.add(combinedDiggingFeesSarquito.mul(2))
       );
     });
+
     it("does not transfer any funds to protocol fees if all archaeologists have supplied keyshares", async function () {
       const { thirdPartyFacet, viewStateFacet } = await getContracts();
       const {


### PR DESCRIPTION
## Overview

This PR updates the contracts to work with digging fees per second instead a constant digging fee value.

Archaeologists will set a minimum digging fee per second that they would like to earn for being cursed on a sarcophagus. 

Once an archaeologist is bound to a sarcophagus, they are contractually bound to earn the agreed upon digging fees per second for the the lifetime of the sarcophagus, even if they change their minimum on their profile.

Payouts are calculated based on how much time interval exists between the agreed upon resurrection time and either: 
 - the creation time for new sarcophagi
 - the previous rewrap time for a sarcophagus being rewrapped (in which case the *new* resurrection time is the upper bound of the interval).

Archaeologist bonds are similarly locked when being cursed, in order to keep a 1-to-1 ratio of expected payout to locked bond.

## Refactoring done in this PR:
 - `LibBonds.sol` refactored, mostly to remove redundancy and rename functions more descriptively.
 - A new `LibBonds.curseArchaeologist` now handles all operations toward the action of "cursing" an archaeologist. Code that was doing this in `EmbalmerFacet.createSarcophagus` has been accordingly moved.

 - `LibBonds.freeArchaeologist` has been updated to internally calculate digging fees due and add this to the arch rewards.
- A side effect of the above update is that for `bury`, the resurrection time cannot be updated to `MaxUInt256` before the call to `freeArchaeologist`, as reward payout depends on the sarcophagus `resurrectionTime`. I considered having `freeArchaologist` accept this interval instead, but decided against it because it would mean deferring this calculation to its other callers. **(Need to consider potential security implications of this order of execution)**

- Moved `revert SenderNotEmbalmerOrAdmin(msg.sender);` higher up the logic -- no point checking anything else if the sender is unauthorised anyways.

---

Tests have also been updated to account for these updates -- all passing. I have not however considered if more tests need to added or not, to specifically test the new time-based rewarding+bonding mechanism.