### PR TITLE
Updates to storage

### DIFF
--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -204,7 +204,7 @@ contract ArchaeologistFacet {
     /// sarcophagus resurrection window.
     /// Pays digging fees to the archaeologist and releases their locked bond.
     /// Cannot be called on a compromised or buried sarcophagus.
-    /// @param sarcoId The identifier of the sarcophagus to unwrap
+    /// @param sarcoId The identifier of the sarcophagus for which the archaeologist is responsible
     /// @param privateKey The private key the archaeologist is publishing
     function publishPrivateKey(bytes32 sarcoId, bytes32 privateKey) external {
         AppStorage storage s = LibAppStorage.getAppStorage();

--- a/contracts/facets/ArchaeologistFacet.sol
+++ b/contracts/facets/ArchaeologistFacet.sol
@@ -56,6 +56,9 @@ contract ArchaeologistFacet {
     /// @param archaeologistAddress address of publishing archaeologist
     error ArchaeologistAlreadyPublishedPrivateKey(address archaeologistAddress);
 
+    /// @notice Archaeologist has attempted to set a zero minimumDiggingFeePerSecond or maximumRewrapInterval
+    error CannotSetZeroProfileValue();
+
     /// @notice Archaeologist has attempted to publish the incorrect private key for a sarcophagus
     /// @param archaeologistAddress address of publishing archaeologist
     /// @param publicKey publicKey stored for archaeologist on the sarcophagus
@@ -82,9 +85,12 @@ contract ArchaeologistFacet {
         // verify that the archaeologist does not already exist
         LibUtils.revertIfArchProfileExists(msg.sender);
 
+        if (maximumRewrapInterval == 0 || minimumDiggingFeePerSecond == 0) {
+            revert CannotSetZeroProfileValue();
+        }
+
         // create a new archaeologist
         LibTypes.ArchaeologistProfile memory newArch = LibTypes.ArchaeologistProfile({
-            exists: true,
             peerId: peerId,
             minimumDiggingFeePerSecond: minimumDiggingFeePerSecond,
             maximumRewrapInterval: maximumRewrapInterval,
@@ -126,6 +132,10 @@ contract ArchaeologistFacet {
         AppStorage storage s = LibAppStorage.getAppStorage();
         // verify that the archaeologist exists
         LibUtils.revertIfArchProfileDoesNotExist(msg.sender);
+
+        if (maximumRewrapInterval == 0 || minimumDiggingFeePerSecond == 0) {
+            revert CannotSetZeroProfileValue();
+        }
 
         LibTypes.ArchaeologistProfile storage existingArch = s.archaeologistProfiles[msg.sender];
         existingArch.peerId = peerId;
@@ -245,7 +255,7 @@ contract ArchaeologistFacet {
 
         // Confirm that the private key being submitted matches the public key stored on the
         // sarcophagus for this archaeologist
-        if (!LibPrivateKeys.isPublicKeyFromPrivateKey(privateKey, cursedArchaeologist.publicKey)) {
+        if (!LibPrivateKeys.isPublicKeyOfPrivateKey(privateKey, cursedArchaeologist.publicKey)) {
             revert ArchaeologistPublishedIncorrectPrivateKey(
                 msg.sender,
                 cursedArchaeologist.publicKey,

--- a/contracts/facets/EmbalmerFacet.sol
+++ b/contracts/facets/EmbalmerFacet.sol
@@ -128,6 +128,8 @@ contract EmbalmerFacet {
 
     error NewResurrectionTimeInPast(uint256 currentTime, uint256 newResurrectionTime);
 
+    error NewResurrectionTimeIsZero();
+
     error NewResurrectionTimeTooFarInFuture(
         uint256 resurrectionTime,
         uint256 sarcophagusMaximumRewrapInterval,
@@ -309,6 +311,10 @@ contract EmbalmerFacet {
             revert LibErrors.SarcophagusDoesNotExist(sarcoId);
         }
 
+        if (resurrectionTime == 0) {
+            revert NewResurrectionTimeIsZero();
+        }
+
         // Confirm the sarcophagus has not been compromised
         if (sarcophagus.isCompromised) {
             revert LibErrors.SarcophagusCompromised(sarcoId);
@@ -432,7 +438,6 @@ contract EmbalmerFacet {
             }
         }
 
-        // TODO: Evaluate security cost of this setter being after calls to `freeArchaeologist` which unlocks bond and rewards archaeologists
         // Set resurrection time to infinity
         sarcophagus.resurrectionTime = 2 ** 256 - 1;
 

--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -33,7 +33,7 @@ contract ViewStateFacet {
 
         for (uint256 i = 0; i < addresses.length; i++) {
             // Check that the archaeologist profile exists
-            if (!s.archaeologistProfiles[addresses[i]].exists) {
+            if (s.archaeologistProfiles[addresses[i]].maximumRewrapInterval == 0) {
                 continue;
             }
             profiles[i] = s.archaeologistProfiles[addresses[i]];

--- a/contracts/libraries/LibErrors.sol
+++ b/contracts/libraries/LibErrors.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.13;
  * uses.
  */
 library LibErrors {
-
     error ArchaeologistNotOnSarcophagus(address archaeologist);
 
     error NotEnoughCursedBond(uint256 cursedBond, uint256 amount);
@@ -30,5 +29,4 @@ library LibErrors {
         // address we expected to have signed the data
         address expectedAddress
     );
-
 }

--- a/contracts/libraries/LibPrivateKeys.sol
+++ b/contracts/libraries/LibPrivateKeys.sol
@@ -18,7 +18,7 @@ library LibPrivateKeys {
      * @return bool indicating whether the public key is derived from the
      * private key
      */
-    function isPublicKeyFromPrivateKey(bytes32 privKey, bytes storage pubKey) internal view returns (bool) {
+    function isPublicKeyOfPrivateKey(bytes32 privKey, bytes storage pubKey) internal view returns (bool) {
         // removes the 0x04 prefix from an uncompressed public key
         bytes memory truncatedPublicKey = new bytes(pubKey.length-1);
         for (uint256 i = 1; i < pubKey.length; i++) {

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -6,14 +6,14 @@ pragma solidity ^0.8.13;
  */
 library LibTypes {
     struct Sarcophagus {
-        // never zero - use for existence checks
+        // Also used for existence checks -- does not exist if 0
         uint256 resurrectionTime;
         uint256 previousRewrapTime;
         // todo: run gas cost evaluation on storing isCompromised vs looping through stored archaeologists and checking isAccused
         bool isCompromised;
         bool isCleaned;
-        string name;
         uint8 threshold;
+        string name;
         uint256 maximumRewrapInterval;
         uint256 maximumResurrectionTime;
         string arweaveTxId;
@@ -24,25 +24,26 @@ library LibTypes {
     }
 
     struct CursedArchaeologist {
-        // never empty - use for existence checks
-        bytes publicKey;
-        bytes32 privateKey;
-        bool isAccused;
         uint256 diggingFeePerSecond;
-    }
-
-    struct ArchaeologistProfile {
-        bool exists; // todo: use peerid.length instead of exists
-        string peerId;
-        uint256 minimumDiggingFeePerSecond;
-        uint256 maximumRewrapInterval;
-        uint256 freeBond;
-        uint256 cursedBond;
+        // Also used for unwrap checks -- has not unwrapped if 0
+        bytes32 privateKey;
+        // Also used for curse checks -- is not bonded if length is 0
+        bytes publicKey;
+        bool isAccused;
     }
 
     struct Signature {
         uint8 v;
         bytes32 r;
         bytes32 s;
+    }
+
+    struct ArchaeologistProfile {
+        // Also used for existence checks -- does not exist if 0
+        uint256 maximumRewrapInterval;
+        string peerId;
+        uint256 minimumDiggingFeePerSecond;
+        uint256 freeBond;
+        uint256 cursedBond;
     }
 }

--- a/contracts/libraries/LibTypes.sol
+++ b/contracts/libraries/LibTypes.sol
@@ -25,7 +25,7 @@ library LibTypes {
 
     struct CursedArchaeologist {
         uint256 diggingFeePerSecond;
-        // Also used for unwrap checks -- has not unwrapped if 0
+        // Also used for publish checks -- has not published if 0
         bytes32 privateKey;
         // Also used for curse checks -- is not bonded if length is 0
         bytes publicKey;

--- a/contracts/libraries/LibUtils.sol
+++ b/contracts/libraries/LibUtils.sol
@@ -102,7 +102,7 @@ library LibUtils {
     function revertIfArchProfileExists(address archaeologist) internal view {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
-        if (s.archaeologistProfiles[archaeologist].exists) {
+        if (s.archaeologistProfiles[archaeologist].maximumRewrapInterval != 0) {
             revert LibErrors.ArchaeologistProfileExistsShouldBe(false, archaeologist);
         }
     }
@@ -113,7 +113,7 @@ library LibUtils {
     function revertIfArchProfileDoesNotExist(address archaeologist) internal view {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
-        if (!s.archaeologistProfiles[archaeologist].exists) {
+        if (s.archaeologistProfiles[archaeologist].maximumRewrapInterval == 0) {
             revert LibErrors.ArchaeologistProfileExistsShouldBe(true, archaeologist);
         }
     }

--- a/contracts/proxy/LibPrivateKeysProxy.sol
+++ b/contracts/proxy/LibPrivateKeysProxy.sol
@@ -11,7 +11,7 @@ contract LibPrivateKeysTest {
 
     function keyVerification(bytes32 privKey, bytes calldata pubKey) public {
         storedPublicKey = pubKey;
-        if (LibPrivateKeys.isPublicKeyFromPrivateKey(privKey, storedPublicKey)) {
+        if (LibPrivateKeys.isPublicKeyOfPrivateKey(privKey, storedPublicKey)) {
             emit True();
         } else {
             emit False();

--- a/contracts/storage/AppStorageInit.sol
+++ b/contracts/storage/AppStorageInit.sol
@@ -16,7 +16,6 @@ contract AppStorageInit {
     ) external {
         AppStorage storage s = LibAppStorage.getAppStorage();
 
-        // Add the ERC20 token to app storage (Sarco)
         s.sarcoToken = sarcoToken;
         s.protocolFeeBasePercentage = protocolFeeBasePercentage;
         s.gracePeriod = gracePeriod;

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -55,7 +55,7 @@ struct AppStorage {
 }
 
 library LibAppStorage {
-    bytes32 constant DIAMOND_STORAGE_POSITION = keccak256("sarcophagus.storage.dev1");
+    bytes32 constant DIAMOND_STORAGE_POSITION = keccak256("sarcophagus.storage.dev2");
 
     function getAppStorage() internal pure returns (AppStorage storage s) {
         bytes32 position = DIAMOND_STORAGE_POSITION;

--- a/contracts/storage/LibAppStorage.sol
+++ b/contracts/storage/LibAppStorage.sol
@@ -5,20 +5,17 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../libraries/LibTypes.sol";
 
 /**
-* Global diamond storage struct to be shared across facets
-* TODO: Implement diamond storage pattern and consider splitting storage into facet specific structs
-*/
+ * Global diamond storage struct to be shared across facets
+ * TODO: Implement diamond storage pattern and consider splitting storage into facet specific structs
+ */
 struct AppStorage {
-
     // SARCO token contract
     IERC20 sarcoToken;
-
     // total protocol fees available to be withdrawn by the admin
     uint256 totalProtocolFees;
-
     /**
-    * Protocol level admin configurations
-    */
+     * Protocol level admin configurations
+     */
     // % of total digging fees for sarcophagus to charge embalmer on create and rewrap
     uint256 protocolFeeBasePercentage;
     // grace period an archaeologist is given to resurrect a sarcophagus after the resurrection time
@@ -28,36 +25,30 @@ struct AppStorage {
     // window after end of gracePeriod + resurrectionTime where embalmer can claim remaining bonds from archaeologists that have failed to publish private keys
     uint256 embalmerClaimWindow;
 
+    // registered archaeologist addresses
+    address[] archaeologistProfileAddresses;
+
     /**
-    * Ownership mappings
-    */
+     * Ownership mappings
+     */
     // embalmer address => ids of sarcophagi they've created
     mapping(address => bytes32[]) embalmerSarcophagi;
     // archaeologist address =>  ids of sarcophagi they're protecting
     mapping(address => bytes32[]) archaeologistSarcophagi;
     // recipient address =>  ids of sarcophagi they're recipient on
     mapping(address => bytes32[]) recipientSarcophagi;
-
     // public key => archaeologist address
     mapping(bytes => address) publicKeyToArchaeologistAddress;
-
     // sarcophagus id => sarcophagus object
     mapping(bytes32 => LibTypes.Sarcophagus) sarcophagi;
-
-    // archaeologist addresses
-    address[] archaeologistProfileAddresses;
     // archaeologist address => profile
     mapping(address => LibTypes.ArchaeologistProfile) archaeologistProfiles;
-
-
     // current balance of rewards available for the archaeologist to withdraw
     mapping(address => uint256) archaeologistRewards;
-
-
     /**
-    * Archaeologist reputation statistics
-    * todo: could these be organized differently?
-    */
+     * Archaeologist reputation statistics: address => sarcoIds
+     * todo: could these be organized differently?
+     */
     mapping(address => bytes32[]) archaeologistSuccesses;
     mapping(address => bytes32[]) archaeologistAccusals;
     mapping(address => bytes32[]) archaeologistCleanups;


### PR DESCRIPTION
This PR contains minor rearrangements to storage variable so small sized variables may be packed together in the same 256-bit storage slot.

Also adds a few zero-input checks.

Removed `exists` from arch profile -- now using `maximumRewrapInterval == 0` to check if profile does not exist.