### PR TITLE
Modify locked bond on rewrap

### DIFF
--- a/contracts/facets/ViewStateFacet.sol
+++ b/contracts/facets/ViewStateFacet.sol
@@ -249,6 +249,7 @@ contract ViewStateFacet {
 
     struct SarcophagusResponse {
         uint256 resurrectionTime;
+        uint256 previousRewrapTime;
         bool isCompromised;
         bool isCleaned;
         string name;
@@ -298,6 +299,7 @@ contract ViewStateFacet {
         return
             SarcophagusResponse({
                 resurrectionTime: sarcophagus.resurrectionTime,
+                previousRewrapTime: sarcophagus.previousRewrapTime,
                 isCompromised: sarcophagus.isCompromised,
                 isCleaned: sarcophagus.isCleaned,
                 name: sarcophagus.name,

--- a/test/facets/embalmer/rewrapSarcophagus.spec.ts
+++ b/test/facets/embalmer/rewrapSarcophagus.spec.ts
@@ -370,7 +370,7 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
       );
     });
 
-    it.only("Should decrease cursed bond and increase free bond if new digging fee < previous digging fee ", async function () {
+    it("Should decrease cursed bond and increase free bond if new digging fee < previous digging fee ", async function () {
       const { embalmerFacet, viewStateFacet } = await getContracts();
 
       // Set resurrection time for creation to 1 week from now

--- a/test/facets/embalmer/rewrapSarcophagus.spec.ts
+++ b/test/facets/embalmer/rewrapSarcophagus.spec.ts
@@ -170,6 +170,31 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
         `NewResurrectionTimeTooFarInFuture`
       );
     });
+
+    it("there is not enough digging fees to cover the new locked bond amount", async function () {
+      const { embalmerFacet } = await getContracts();
+
+      // Set resurrection time to 1 week from now
+      const resurrectionTime = (await time.latest()) + time.duration.weeks(1);
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists({
+          resurrectionTime,
+        });
+
+      // Increase resurrection time to 3 weeks from now, 3x the original
+      // Less than max res time but way more than double previous res time
+      const tx = embalmerFacet
+        .connect(sarcophagusData.embalmer)
+        .rewrapSarcophagus(
+          sarcophagusData.sarcoId,
+          (await time.latest()) + time.duration.weeks(3)
+        );
+
+      await expect(tx).to.be.revertedWithCustomError(
+        embalmerFacet,
+        `ResurrectionTimeTooFarPastPreviousResurrectionTime`
+      );
+    });
   });
 
   describe("Successfully rewraps a sarcophagus with no accusals", function () {
@@ -271,6 +296,161 @@ describe("EmbalmerFacet.rewrapSarcophagus", () => {
 
       expect(result.resurrectionTime).to.equal(newResurrectionTime);
       await expect(tx).to.emit(embalmerFacet, "RewrapSarcophagus");
+    });
+
+    it("Should increase the cursed bond and decrease the rewards if new digging fee > previous digging fee", async function () {
+      const { embalmerFacet, viewStateFacet } = await getContracts();
+
+      // Set resurrection time for creation to 1 week from now
+      const resurrectionTimeOnCreate =
+        (await time.latest()) + time.duration.weeks(1);
+
+      // Set resurrection time for rewrap to 1.5 weeks from now
+      const resurrectionTimeOnRewrap =
+        (await time.latest()) + time.duration.weeks(1.5);
+
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists({
+          resurrectionTime: resurrectionTimeOnCreate,
+        });
+
+      // Get an archaeologist address
+      const sarcophagus = await viewStateFacet.getSarcophagus(
+        sarcophagusData.sarcoId
+      );
+      const firstArchaeologistAddress = sarcophagus.archaeologistAddresses[0];
+
+      // Get the first archaeologist's cursed bond before rewrap
+      const cursedBondBefore = await viewStateFacet.getCursedBond(
+        firstArchaeologistAddress
+      );
+
+      // Get the archaeologist's rewards before rewrap
+      const rewardsBefore = await viewStateFacet.getRewards(
+        firstArchaeologistAddress
+      );
+
+      // Get first archaeologist's digging fees per second
+      const diggingFeePerSecond = (
+        await viewStateFacet.getArchaeologistProfile(firstArchaeologistAddress)
+      ).minimumDiggingFeePerSecond;
+
+      await embalmerFacet
+        .connect(sarcophagusData.embalmer)
+        .rewrapSarcophagus(sarcophagusData.sarcoId, resurrectionTimeOnRewrap);
+
+      // Get the first archaeologist's cursed bond after rewrap
+      const cursedBondAfter = await viewStateFacet.getCursedBond(
+        firstArchaeologistAddress
+      );
+
+      // Get the archaeologist's rewards after rewrap
+      const rewardsAfter = await viewStateFacet.getRewards(
+        firstArchaeologistAddress
+      );
+
+      const prevDiggingFees = diggingFeePerSecond.mul(
+        sarcophagus.resurrectionTime.sub(sarcophagus.previousRewrapTime)
+      );
+
+      const newDiggingFees = diggingFeePerSecond.mul(
+        BigNumber.from(resurrectionTimeOnRewrap).sub(
+          BigNumber.from(await time.latest())
+        )
+      );
+
+      const diggingFeesDiff = newDiggingFees.sub(prevDiggingFees);
+
+      // Expect the cursed bond after - cursed bond before to be equal to the difference in digging fees
+      expect(cursedBondAfter.sub(cursedBondBefore)).to.equal(diggingFeesDiff);
+
+      // Expect the rewards after - rewards before to be equal to previous digging fee - the digging fee difference
+      expect(rewardsAfter.sub(rewardsBefore)).to.equal(
+        prevDiggingFees.sub(diggingFeesDiff)
+      );
+    });
+
+    it.only("Should decrease cursed bond and increase free bond if new digging fee < previous digging fee ", async function () {
+      const { embalmerFacet, viewStateFacet } = await getContracts();
+
+      // Set resurrection time for creation to 1 week from now
+      const resurrectionTimeOnCreate =
+        (await time.latest()) + time.duration.weeks(1);
+
+      // Set resurrection time for rewrap to 0.5 weeks from now
+      const resurrectionTimeOnRewrap =
+        (await time.latest()) + time.duration.weeks(0.5);
+
+      const { createdSarcophagusData: sarcophagusData } =
+        await createSarcophagusWithRegisteredCursedArchaeologists({
+          resurrectionTime: resurrectionTimeOnCreate,
+        });
+
+      // Get an archaeologist address
+      const sarcophagus = await viewStateFacet.getSarcophagus(
+        sarcophagusData.sarcoId
+      );
+      const firstArchaeologistAddress = sarcophagus.archaeologistAddresses[0];
+
+      // Get the first archaeologist's cursed bond before rewrap
+      const cursedBondBefore = await viewStateFacet.getCursedBond(
+        firstArchaeologistAddress
+      );
+
+      // Get the first archaeologist's free bond before rewrap
+      const freeBondBefore = await viewStateFacet.getFreeBond(
+        firstArchaeologistAddress
+      );
+
+      // Get the archaeologist's rewards before rewrap
+      const rewardsBefore = await viewStateFacet.getRewards(
+        firstArchaeologistAddress
+      );
+
+      // Get first archaeologist's digging fees per second
+      const diggingFeePerSecond = (
+        await viewStateFacet.getArchaeologistProfile(firstArchaeologistAddress)
+      ).minimumDiggingFeePerSecond;
+
+      await embalmerFacet
+        .connect(sarcophagusData.embalmer)
+        .rewrapSarcophagus(sarcophagusData.sarcoId, resurrectionTimeOnRewrap);
+
+      // Get the first archaeologist's cursed bond after rewrap
+      const cursedBondAfter = await viewStateFacet.getCursedBond(
+        firstArchaeologistAddress
+      );
+
+      // Get the first archaeologist's free bond after rewrap
+      const freeBondAfter = await viewStateFacet.getFreeBond(
+        firstArchaeologistAddress
+      );
+
+      // Get the archaeologist's rewards after rewrap
+      const rewardsAfter = await viewStateFacet.getRewards(
+        firstArchaeologistAddress
+      );
+
+      const prevDiggingFees = diggingFeePerSecond.mul(
+        sarcophagus.resurrectionTime.sub(sarcophagus.previousRewrapTime)
+      );
+
+      const newDiggingFees = diggingFeePerSecond.mul(
+        BigNumber.from(resurrectionTimeOnRewrap).sub(
+          BigNumber.from(await time.latest())
+        )
+      );
+
+      const diggingFeesDiff = prevDiggingFees.sub(newDiggingFees);
+
+      // Expect the difference in cursed bond to be equal to the difference in diggingFees
+      expect(cursedBondBefore.sub(cursedBondAfter)).to.equal(diggingFeesDiff);
+
+      // Expect the difference in free bond to be equal to the difference in diggingFees
+      expect(freeBondAfter.sub(freeBondBefore)).to.equal(diggingFeesDiff);
+
+      // Expect the difference in rewards to be equal to the previous digging fees
+      expect(rewardsAfter.sub(rewardsBefore)).to.equal(prevDiggingFees);
     });
   });
   describe("Successfully rewraps a sarcophagus with fewer than k accusals", function () {

--- a/test/facets/helpers/sarcophagus.ts
+++ b/test/facets/helpers/sarcophagus.ts
@@ -190,6 +190,7 @@ export const createSarcophagusWithRegisteredCursedArchaeologists =
     totalArchaeologists?: number;
     threshold?: number;
     maximumRewrapIntervalSeconds?: number;
+    resurrectionTime?: number;
   }): Promise<{
     cursedArchaeologists: ArchaeologistData[];
     createdSarcophagusData: SarcophagusData;


### PR DESCRIPTION
Modifies the rewrap function to change the arch locked bond when the interval changes and adds tests for this functionality. This PR assumes a 1:1 ratio between digging fees and locked bond, although it shouldn't be difficult to make the necessary changes when we change that 1:1 ratio.